### PR TITLE
Create 增加双击托盘区打开设置功能

### DIFF
--- a/增加双击托盘区打开设置功能
+++ b/增加双击托盘区打开设置功能
@@ -1,0 +1,248 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+#Warn All, Off
+ListLines False
+KeyHistory 0
+ProcessSetPriority "High" ; 
+SendMode "Input"
+SetKeyDelay -1, -1
+SetMouseDelay -1
+SetWinDelay -1
+SetDefaultMouseSpeed 0
+SetTitleMatchMode 3
+DllCall("winmm\timeBeginPeriod", "UInt", 1)
+OnExit (*) => DllCall("winmm\timeEndPeriod", "UInt", 1)
+
+; 获取权限
+if not A_IsAdmin
+{
+    try
+    {
+        if A_IsCompiled
+            Run '*RunAs "' A_ScriptFullPath '" /restart'
+        else
+            Run '*RunAs "' A_AhkPath '" /restart "' A_ScriptFullPath '"'
+    }
+    ExitApp
+}
+
+; 包含全局变量
+#Include ./lib/global.ahk
+
+; 初始化
+LoadSettings()
+HotkeyOn()
+
+; == 功能实现 ==
+; 按下暂停
+ActionPressPause(ThisHotkey) {
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 松开暂停
+ActionReleasePause(ThisHotkey) {
+    if InStr(ThisHotkey, "Wheel") == 0 {
+        PureKeyWait(ThisHotkey)
+    }
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+}
+; 切换倍速
+ActionGameSpeed(ThisHotkey) {
+    Send "{f Down}"
+    USleep(Delay)
+    Send "{f Up}"
+    Send "{g Down}"
+    USleep(Delay)
+    Send "{g Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 前进33ms
+Action33ms(ThisHotkey) {
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    USleep(29 - Delay)
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 前进166ms
+Action166ms(ThisHotkey) {
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    USleep(166 - Delay)
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 暂停选中
+ActionPauseSelect(ThisHotkey) {
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{Click Left}"
+    Send "{ESC Up}"
+    USleep(Delay * 1.2)
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 干员技能
+ActionSkill(ThisHotkey) {
+    Send "{e Down}"
+    USleep(Delay)
+    Send "{e Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 干员撤退
+ActionRetreat(ThisHotkey) {
+    Send "{q Down}"
+    USleep(Delay)
+    Send "{q Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 一键技能
+ActionOneClickSkill(ThisHotkey) {
+    Send "{Click Left}"
+    USleep(Delay * 1.5) 
+    Send "{e Down}"
+    USleep(Delay * 1.3)
+    Send "{e Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 一键撤退
+ActionOneClickRetreat(ThisHotkey) {
+    Send "{Click Left}"
+    USleep(Delay * 1.5)
+    Send "{q Down}"
+    USleep(Delay * 1.3)
+    Send "{q Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 暂停技能
+ActionPauseSkill(ThisHotkey) {
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{Click Left}"
+    Send "{ESC Up}"
+    USleep(Delay * 1.4)
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    Send "{e Down}"
+    USleep(Delay * 1.2)
+    Send "{e Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+; 暂停撤退
+ActionPauseRetreat(ThisHotkey) {
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{Click Left}"
+    Send "{ESC Up}"
+    USleep(Delay * 1.4)
+    Send "{ESC Down}"
+    USleep(Delay)
+    Send "{ESC Up}"
+    Send "{q Down}"
+    USleep(Delay * 1.2)
+    Send "{q Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+
+; 模拟鼠标左键点击
+RbuttonClick(ThisHotkey) {
+    Send "{Click Left}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+
+; 高精度延迟
+USleep(delay_ms) {
+    static freq := 0
+    static isHighRes := false
+    if (delay_ms <= Delay) {
+        delay_ms := Delay
+    }
+    if (freq = 0) {
+        DllCall("QueryPerformanceFrequency", "Int64*", &freq)
+    }
+    if (!isHighRes) {
+        DllCall("winmm\timeBeginPeriod", "UInt", 1)
+        isHighRes := true
+    }
+    start := 0
+    DllCall("QueryPerformanceCounter", "Int64*", &start)
+    target := start + (delay_ms * freq / 1000)
+    Loop {
+        current := 0
+        DllCall("QueryPerformanceCounter", "Int64*", &current)
+        if (current >= target)
+            break
+        remaining := (target - current) * 1000 / freq
+        if (remaining > 2)
+            DllCall("Sleep", "UInt", 1) 
+    }
+}
+; 去除前缀修饰符
+PureKeyWait(ThisHotkey) {
+    pureKey := RegExReplace(ThisHotkey, "^[~*$#!^+&]+")
+    KeyWait(pureKey)
+}
+
+; --- 包含剩余模块 ---
+#Include ./lib/gui.ahk
+#Include ./lib/setting.ahk
+#Include ./lib/key_bind.ahk
+
+; ==============================================================================
+; === 新增：托盘图标配置 (必须放在脚本末尾以确保GUI已加载) ===
+; ==============================================================================
+A_TrayMenu.Delete()
+A_TrayMenu.Add("设置中心", TrayShowGui)
+A_TrayMenu.Default := "设置中心" ; 双击托盘图标将执行此项
+A_TrayMenu.Add("重启助手", (*) => Reload())
+A_TrayMenu.Add() ; 分割线
+A_TrayMenu.Add("退出程序", (*) => ExitApp())
+
+TrayShowGui(*) {
+    try {
+        if IsSet(MyGui) {
+            MyGui.Show()
+            ; 如果 global.ahk 里定义了 WindowName 则置顶，否则置顶游戏进程
+            target := IsSet(WindowName) ? WindowName : "ahk_exe Arknights.exe"
+            WinActivate(target)
+            WinRestore(target)
+        }
+    }
+}


### PR DESCRIPTION
基于1.0.8版本：
  增加了 WinActivate 和 WinRestore。这是为了防止 PC 版游戏全屏显示时，双击打开的设置窗口藏在游戏窗口后面的情况

   同时新增托盘区右键重启选项(不知道有没有用

## Summary by Sourcery

在系统托盘中添加交互，以打开和管理设置窗口。

新功能：
- 允许通过双击系统托盘图标打开设置窗口。
- 在系统托盘的上下文菜单（右键菜单）中添加“重启”选项。

错误修复：
- 确保设置窗口能够被还原并激活，从而不会被全屏 PC 游戏窗口遮挡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add system tray interactions to open and manage the settings window.

New Features:
- Allow opening the settings window by double-clicking the system tray icon.
- Add a restart option to the system tray context (right-click) menu.

Bug Fixes:
- Ensure the settings window is restored and activated so it is not hidden behind a fullscreen PC game window.

</details>