### PR TITLE
技能撤退点击间隔的自定义前置；双击托盘区图标打开设置；

### DIFF
--- a/src/lib/global.ahk
+++ b/src/lib/global.ahk
@@ -59,6 +59,8 @@ global WaitingModify := false
 global DelayA := 35.3 ; 30帧
 global DelayB := 19.6 ; 60帧
 global DelayC := 11.3 ; 120帧
+; 默认技能/撤退点击延迟
+global SkillAndRetreatDelay := 1
 
 ; ==配置文件路径==
 ConfigDir := A_AppData "\ArknightsFrameAssistant\PC"

--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -75,6 +75,7 @@ MyGui.Add("Text", "xm y+15 w1 h1")
 A_TrayMenu.Delete
 A_TrayMenu.Add("打开按键设置", (*) => ShowSettings())
 A_TrayMenu.Add("退出", (*) => ExitApp())
+A_TrayMenu.Default := "打开按键设置"
 ; 焦点修正，不豪堪
 ; OnMessage(0x0111, (*) => (MyGui.FocusedCtrl ? "" : btnSave.Focus()))
 

--- a/src/lib/setting.ahk
+++ b/src/lib/setting.ahk
@@ -22,6 +22,7 @@ DelaySetting() {
     else if (ImportantSettings["Frame"] == 3) {
         Delay := DelayC
     }
+    SkillAndRetreatDelay := Delay
 }
 
 ; 记录热键并写入配置文件

--- a/src/main.ahk
+++ b/src/main.ahk
@@ -125,7 +125,7 @@ ActionRetreat(ThisHotkey) {
 ; 一键技能
 ActionOneClickSkill(ThisHotkey) {
     Send "{Click Left}"
-    USleep(Delay * 1.5)
+    USleep(SkillAndRetreatDelay * 1.5)
     Send "{e Down}"
     USleep(Delay * 1.3)
     Send "{e Up}"
@@ -136,7 +136,7 @@ ActionOneClickSkill(ThisHotkey) {
 ; 一键撤退
 ActionOneClickRetreat(ThisHotkey) {
     Send "{Click Left}"
-    USleep(Delay * 1.5)
+    USleep(SkillAndRetreatDelay * 1.5)
     Send "{q Down}"
     USleep(Delay * 1.3)
     Send "{q Up}"
@@ -150,7 +150,7 @@ ActionPauseSkill(ThisHotkey) {
     USleep(Delay)
     Send "{Click Left}"
     Send "{ESC Up}"
-    USleep(Delay * 1.4)
+    USleep(SkillAndRetreatDelay * 1.4)
     Send "{ESC Down}"
     USleep(Delay)
     Send "{ESC Up}"
@@ -167,7 +167,7 @@ ActionPauseRetreat(ThisHotkey) {
     USleep(Delay)
     Send "{Click Left}"
     Send "{ESC Up}"
-    USleep(Delay * 1.4)
+    USleep(SkillAndRetreatDelay * 1.4)
     Send "{ESC Down}"
     USleep(Delay)
     Send "{ESC Up}"


### PR DESCRIPTION
## Summary by Sourcery

使技能与撤退点击延迟可配置，并调整托盘图标行为。

新功能：
- 允许通过与当前帧设置绑定的专用全局延迟值，配置点击与技能/撤退动作之间使用的延迟。
- 通过设置托盘菜单的默认项，可通过双击系统托盘图标打开按键设置窗口。

改进：
- 将技能与撤退相关的延迟统一为使用一个专用的延迟变量，而不是通用延迟值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make skill and retreat click delays configurable and adjust tray icon behavior.

New Features:
- Allow configuring the delay used between click and skill/retreat actions via a dedicated global delay value tied to the selected frame setting.
- Enable opening the key settings window by double-clicking the system tray icon through setting the default tray menu item.

Enhancements:
- Standardize skill and retreat related delays to use a single dedicated delay variable instead of the general delay value.

</details>