### PR TITLE
修复Hook泄露以及未能正确释放的问题

### DIFF
--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -92,9 +92,7 @@ ShowWarning() {
 ; 隐藏GUI
 HideGui(){
     ; 释放可能存在的Hook
-    if(ModifyHook.InProgress) {
-        ModifyHook.Stop()
-    }
+    StopHook()
     MyGui.Hide()
     ; 关闭GUI窗口监控
     SetTimer WatchActiveWindow, 0

--- a/src/lib/key_bind.ahk
+++ b/src/lib/key_bind.ahk
@@ -5,12 +5,20 @@ OnMessage(0x0201, WM_LBUTTONDOWN)
 
 ; 创建Hook
 CreateHook() {
+    global ModifyHook
     ModifyHook := InputHook("L0")
     ModifyHook.VisibleNonText := false
     ModifyHook.KeyOpt("{All}", "E")
     ModifyHook.KeyOpt("{LCtrl}{RCtrl}{LAlt}{RAlt}{LShift}{RShift}", "E")
     ModifyHook.OnEnd := (*) => EndChange(ModifyHook.EndKey)
     ModifyHook.Start()
+}
+; 释放Hook
+StopHook() {
+    global ModifyHook
+    if(ModifyHook.InProgress) {
+        ModifyHook.Stop()
+    }
 }
 
 ; 左键点击判定
@@ -31,9 +39,7 @@ WM_LBUTTONDOWN(wParam, lParam, msg, hwnd) {
             LastEditObject := ControlObj
             WaitingModify := true
             ; 释放可能存在的Hook
-            if(ModifyHook.InProgress) {
-                ModifyHook.Stop()
-            }
+            StopHook()
             ; 配置 Hook
             CreateHook()
         }
@@ -51,9 +57,7 @@ WM_LBUTTONDOWN(wParam, lParam, msg, hwnd) {
                 ControlObj.Value := "请按键"
                 LastEditObject := ControlObj
                 ; 释放可能存在的Hook
-                if(ModifyHook.InProgress) {
-                    ModifyHook.Stop()
-                }
+                StopHook()
                 ; 配置Hook
                 CreateHook()
             }
@@ -69,9 +73,7 @@ WM_LBUTTONDOWN(wParam, lParam, msg, hwnd) {
             LastEditObject := ""
             WaitingModify := false
             ; 释放可能存在的Hook
-            if(ModifyHook.InProgress) {
-                ModifyHook.Stop()
-            }
+            StopHook()
         }
         return
     }
@@ -91,9 +93,7 @@ WatchActiveWindow(){
             LastEditObject := ""
             WaitingModify := false
             ; 释放可能存在的Hook
-            if(ModifyHook.InProgress) {
-                ModifyHook.Stop()
-            }
+            StopHook()
             btnSave.Focus()
         }
     }
@@ -116,20 +116,18 @@ EndChange(Newkey) {
     ; 若有输入按键且不是鼠标左键
     if(Newkey != "") {
         if(Newkey == "Escape" OR Newkey == "Backspace") {
-            try ControlObj.Value := ""
+            ControlObj.Value := ""
         }
         else if(Newkey == "LWin" OR Newkey == "LWin") {
             LastEditObject.Value := OriginalValue
         }
         else {
-            try ControlObj.Value := Newkey
+            ControlObj.Value := Newkey
         }
     }
     LastEditObject := ""
     WaitingModify := false
-    if(ModifyHook.InProgress) {
-        ModifyHook.Stop()
-    }
+    StopHook()
     btnSave.Focus()
 }
 

--- a/src/lib/setting.ahk
+++ b/src/lib/setting.ahk
@@ -27,9 +27,8 @@ DelaySetting() {
 
 ; 记录热键并写入配置文件
 HotkeyIniWrite() {
-    if(ModifyHook.InProgress) {
-        ModifyHook.Stop()
-    }
+    ; 释放可能存在的Hook
+    StopHook()
     SavedObj := MyGui.Submit(0) 
     UsedKeys := Map()
     for keyVar, keyName in KeyNames {


### PR DESCRIPTION
CreateHook函数缺少全局变量的定义，导致重复创建Hook，且后续函数仅能正确释放最后一个创建的Hook，造成Hook泄露

## Summary by Sourcery

确保键盘输入钩子作为单一全局实例进行管理，并在所有 GUI 工作流中一致地释放，以避免钩子泄漏。

Bug Fixes:
- 在创建钩子的函数中将输入钩子声明为全局变量，以防止创建多个未管理的钩子实例。
- 将停止钩子的逻辑集中化，这样在更改绑定、保存设置或隐藏 GUI 时，所有代码路径都能可靠地停止任何活动中的钩子。
- 移除控制值赋值周围不必要的 try 块，避免在更新按键绑定字段时掩盖错误。

Enhancements:
- 引入可复用的 `StopHook` 辅助函数，用于封装钩子清理逻辑，并减少各事件处理器之间的重复代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure keyboard input hook is managed as a single global instance and consistently released across GUI workflows to avoid hook leaks.

Bug Fixes:
- Declare the input hook as a global variable in the hook creation function to prevent creating multiple unmanaged hook instances.
- Centralize hook stopping logic so all code paths reliably stop any active hook when changing bindings, saving settings, or hiding the GUI.
- Remove unnecessary try blocks around control value assignments to avoid masking errors when updating key-binding fields.

Enhancements:
- Introduce a reusable StopHook helper to encapsulate hook cleanup and reduce duplication across event handlers.

</details>