### PR TITLE
feat(settings): 新增启动时自动隐藏到托盘功能

### DIFF
--- a/src/lib/global.ahk
+++ b/src/lib/global.ahk
@@ -37,12 +37,14 @@ global DefaultImportantSettings := Map()
 DefaultImportantSettings["AutoClose"] := "1"
 DefaultImportantSettings["AutoOpen"] := "1"
 DefaultImportantSettings["Frame"] := "3"
+DefaultImportantSettings["AutoHideToTray"] := "0"  ; 新增：启动时自动隐藏到托盘，默认关闭
 ; 重要设置
 global ImportantSettings := DefaultImportantSettings.Clone()
 ; 重要设置映射
 global ImportantNames := Map(
     "AutoClose", "自动退出",
     "AutoOpen",  "自动打开设置界面",
+    "AutoHideToTray", "启动时自动隐藏到托盘",  ; 新增映射
     "Frame","游戏内帧数设置"
 )
 ; 游戏状态

--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -42,6 +42,8 @@ MyGui.Add("Checkbox", "x30 y+20 h24 vAutoClose", " 随游戏进程关闭自动�
 MyGui.Add("Checkbox", "x+20 yp h24 vAutoOpen", " 小助手启动时自动打开设置窗口")
 MyGui["AutoClose"].Value := ImportantSettings["AutoClose"]
 MyGui["AutoOpen"].Value := ImportantSettings["AutoOpen"]
+MyGui.Add("Checkbox", "x30 y+12 h24 vAutoHideToTray", " 启动时自动隐藏到托盘（首次启动生效）")
+MyGui["AutoHideToTray"].Value := ImportantSettings["AutoHideToTray"]
 MyGui.Add("Text", "x30 y+12", "游戏内帧数:")
 GuiFrame := MyGui.Add("DropDownList", "x+12 y+-18 vFrame AltSubmit", ["30", "60", "120"])
 MyGui["Frame"].Value := ImportantSettings["Frame"]
@@ -106,7 +108,11 @@ ShowSettings() {
     SetTimer WatchActiveWindow, 50
 }
 
-; 随脚本启动打开GUI界面
-if(ImportantSettings["AutoOpen"] == 1) {
+; 启动行为控制（优先级：AutoHideToTray > AutoOpen）
+if(ImportantSettings["AutoHideToTray"] == 1) {
+    ; 启动时自动隐藏到托盘，不显示界面
+}
+else if(ImportantSettings["AutoOpen"] == 1) {
+    ; 启动时显示设置界面
     ShowSettings()
 }

--- a/src/lib/setting.ahk
+++ b/src/lib/setting.ahk
@@ -59,6 +59,7 @@ HotkeyIniWrite() {
     IniWrite(SavedObj.OneClickRetreat, INI_FILE, "Hotkeys", "OneClickRetreat")
     IniWrite(SavedObj.AutoClose, INI_FILE, "Main", "AutoClose")
     IniWrite(SavedObj.AutoOpen,  INI_FILE, "Main", "AutoOpen")
+    IniWrite(SavedObj.AutoHideToTray, INI_FILE, "Main", "AutoHideToTray")
     IniWrite(SavedObj.Frame,  INI_FILE, "Main", "Frame")
 }
 


### PR DESCRIPTION
预期目标实现如下（已经通过DEBUG验证）：
1. 首次启动exe时的行为控制：
   - 当用户第一次点击exe启动应用时，可以选择两种模式之一： 
     - a) 直接执行"保存设置"的相同逻辑，不显示设置窗口，直接最小化到系统托盘区域运行 
     - b) 继续当前行为，即启动时显示设置界面供用户配置
2. 配置项添加需求：
   - 在现有的设置UI界面中增加一个新的配置选项
   - 该选项应为复选框或开关，标题为"启动时自动隐藏到托盘"或类似含义的文字
   - 此配置项应该能够控制上述启动行为的选择
3. 后续操作保持不变：
   - 用户仍可以通过右下角托盘区图标右键菜单打开设置界面进行调整
   - 托盘图标的其他功能保持原有逻辑
<img width="774" height="705" alt="启动时自动隐藏到托盘" src="https://github.com/user-attachments/assets/3e0e3cba-4fac-4bfe-980c-77bad4d8df2f" />

## Summary by Sourcery

添加一个启动选项，使应用程序在启动时自动最小化到系统托盘，而不是打开设置窗口。

新功能：
- 引入 `AutoHideToTray` 设置，用于控制应用在首次启动时是隐藏到托盘，还是显示设置界面。

改进：
- 调整启动行为，使其优先根据新的自动隐藏到托盘选项执行，而不是自动打开设置窗口。

日常维护：
- 在配置中持久化新的 `AutoHideToTray` 设置，默认关闭，并将其加入重要设置映射中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a startup option to automatically hide the application to the system tray instead of opening the settings window.

New Features:
- Introduce an 'AutoHideToTray' setting that controls whether the app hides to the tray on first startup instead of showing the settings UI.

Enhancements:
- Adjust startup behavior to prioritize the new auto-hide-to-tray option over automatically opening the settings window.

Chores:
- Persist the new 'AutoHideToTray' setting in configuration with a default of disabled and include it in the important settings map.

</details>