### PR TITLE
对预发布版本的识别有问题，回滚至上一版本

### DIFF
--- a/src/lib/updater/version_checker.ahk
+++ b/src/lib/updater/version_checker.ahk
@@ -2,7 +2,7 @@
 
 class VersionChecker {
     ; GitHub API地址
-    static ApiUrl := "https://api.github.com/repos/CloudTracey/arknights-frame-assistant/releases"
+    static ApiUrl := "https://api.github.com/repos/CloudTracey/arknights-frame-assistant/releases/latest"
     
     ; 缓存文件路径
     static CacheFile := ""
@@ -144,16 +144,15 @@ class VersionChecker {
         }
     }
     
-    ; 内部：比较版本号（支持语义化版本规范 SemVer 2.0.0）
+    ; 内部：比较版本号
     ; 返回: -1(本地<远程), 0(相等), 1(本地>远程)
     static _CompareVersions(localVersion, remoteVersion) {
-        localParsed := this._ParseVersion(localVersion)
-        remoteParsed := this._ParseVersion(remoteVersion)
+        localParts := this._ParseVersion(localVersion)
+        remoteParts := this._ParseVersion(remoteVersion)
         
-        ; 比较主版本、次版本、修订号
         Loop 3 {
-            localNum := localParsed.numbers[A_Index]
-            remoteNum := remoteParsed.numbers[A_Index]
+            localNum := localParts[A_Index]
+            remoteNum := remoteParts[A_Index]
             
             if (localNum < remoteNum)
                 return -1
@@ -161,125 +160,26 @@ class VersionChecker {
                 return 1
         }
         
-        ; 主版本号相同时，比较预发布标识符
-        ; 规则：正式版本 > 预发布版本（如 v1.0.0 > v1.0.0-alpha）
-        localHasPre := localParsed.prerelease.Length > 0
-        remoteHasPre := remoteParsed.prerelease.Length > 0
-        
-        if (!localHasPre && !remoteHasPre) {
-            return 0  ; 都是正式版本且主版本号相同
-        }
-        if (!localHasPre && remoteHasPre) {
-            return 1  ; 本地是正式版本，远程是预发布版本
-        }
-        if (localHasPre && !remoteHasPre) {
-            return -1  ; 本地是预发布版本，远程是正式版本
-        }
-        
-        ; 都是预发布版本，逐个比较标识符
-        return this._ComparePrerelease(localParsed.prerelease, remoteParsed.prerelease)
+        return 0
     }
     
-    ; 内部：解析版本号 vX.Y.Z[-prerelease][+metadata]
-    ; 返回: {numbers: [X, Y, Z], prerelease: [ident1, ident2, ...], metadata: ""}
+    ; 内部：解析版本号 vX.Y.Z -> [X, Y, Z]
     static _ParseVersion(versionStr) {
         ; 移除前缀 'v' 或 'V'
         cleanVersion := RegExReplace(versionStr, "^[vV]", "")
         
-        ; 分离构建元数据（+号后的内容，不参与版本比较）
-        metadata := ""
-        plusPos := InStr(cleanVersion, "+")
-        if (plusPos > 0) {
-            metadata := SubStr(cleanVersion, plusPos + 1)
-            cleanVersion := SubStr(cleanVersion, 1, plusPos - 1)
-        }
+        parts := StrSplit(cleanVersion, ".")
+        result := []
         
-        ; 分离预发布标识符（-号后的内容）
-        prerelease := []
-        hyphenPos := InStr(cleanVersion, "-")
-        versionCore := cleanVersion
-        if (hyphenPos > 0) {
-            versionCore := SubStr(cleanVersion, 1, hyphenPos - 1)
-            prereleaseStr := SubStr(cleanVersion, hyphenPos + 1)
-            prerelease := StrSplit(prereleaseStr, ".")
-        }
-        
-        ; 解析主版本号、次版本号、修订号
-        parts := StrSplit(versionCore, ".")
-        numbers := []
         Loop 3 {
             if (A_Index <= parts.Length) {
-                ; 尝试转换为整数，如果失败则使用 0
-                try {
-                    numbers.Push(Integer(parts[A_Index]))
-                } catch {
-                    numbers.Push(0)
-                }
+                result.Push(Integer(parts[A_Index]))
             } else {
-                numbers.Push(0)
+                result.Push(0)
             }
         }
         
-        return {numbers: numbers, prerelease: prerelease, metadata: metadata}
-    }
-    
-    ; 内部：比较预发布标识符
-    ; 按照 SemVer 规范：数字标识符按数值比较，字母标识符按 ASCII 比较
-    ; 数字标识符优先级低于字母标识符
-    static _ComparePrerelease(localPre, remotePre) {
-        maxLen := Max(localPre.Length, remotePre.Length)
-        
-        Loop maxLen {
-            ; 获取当前位置的标识符
-            localIdent := A_Index <= localPre.Length ? localPre[A_Index] : ""
-            remoteIdent := A_Index <= remotePre.Length ? remotePre[A_Index] : ""
-            
-            ; 如果一个版本有更多标识符，则另一个版本缺少标识符意味着优先级更低
-            if (localIdent == "")
-                return -1
-            if (remoteIdent == "")
-                return 1
-            
-            ; 判断标识符类型
-            localIsNum := this._IsNumeric(localIdent)
-            remoteIsNum := this._IsNumeric(remoteIdent)
-            
-            ; 数字标识符优先级低于字母标识符
-            if (localIsNum && !remoteIsNum)
-                return -1
-            if (!localIsNum && remoteIsNum)
-                return 1
-            
-            ; 同类型比较
-            if (localIsNum && remoteIsNum) {
-                ; 都是数字，按数值比较
-                localVal := Integer(localIdent)
-                remoteVal := Integer(remoteIdent)
-                if (localVal < remoteVal)
-                    return -1
-                if (localVal > remoteVal)
-                    return 1
-            } else {
-                ; 都是字母（或混合），按 ASCII 顺序比较
-                if (localIdent < remoteIdent)
-                    return -1
-                if (localIdent > remoteIdent)
-                    return 1
-            }
-        }
-        
-        return 0  ; 所有标识符相同
-    }
-    
-    ; 内部：检查字符串是否为纯数字
-    static _IsNumeric(str) {
-        if (str == "")
-            return false
-        Loop Parse str {
-            if (A_LoopField < "0" || A_LoopField > "9")
-                return false
-        }
-        return true
+        return result
     }
     
     ; 内部：从JSON字符串中提取字段值


### PR DESCRIPTION
## Summary by Sourcery

将更新器的版本处理方式恢复为更简单的稳定版比较逻辑，仅关注数字版本。

Bug Fixes:
- 修正版本比较逻辑，使预发布标签在通过最新发布接口进行更新检测时不再产生影响。

Enhancements:
- 简化版本解析和比较逻辑，仅处理由三段数字组成的版本，不再包含预发布或元数据部分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the updater’s version handling to a simpler stable-release comparison focused on numeric versions only.

Bug Fixes:
- Correct version comparison so prerelease tags no longer affect update detection when checking against the latest release endpoint.

Enhancements:
- Simplify version parsing and comparison to only handle three-part numeric versions without prerelease or metadata components.

</details>