### PR TITLE
修复了对同一核心版本号的预发布版本进行版本检查失效的的问题

### DIFF
--- a/src/lib/version.ahk
+++ b/src/lib/version.ahk
@@ -2,7 +2,7 @@
 
 class Version {
     ; 当前版本号
-    static Number := "v1.1.0-alpha.1"
+    static Number := "v1.1.0-alpha.2"
     
     ; 获取版本号
     static Get() {


### PR DESCRIPTION
## Sourcery 总结

改进版本检查逻辑，以在查询 GitHub Releases 时正确处理语义化版本和预发布版本的比较。

新特性：
- 在版本比较中支持完整的 SemVer 2.0.0 解析，包括预发布标识符和构建元数据。

缺陷修复：
- 修复在核心版本相同的情况下预发布版本比较失败的问题，现在能够正确区分预发布版本和稳定版本的先后顺序。

改进：
- 将 GitHub Release API 端点从仅请求最新版本改为请求通用的 Release 列表。
- 优化版本比较逻辑，按照 SemVer 规则区分数值型和字母数字混合型的预发布标识符。

杂项：
- 将内部版本号提升至 v1.1.0-alpha.2。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve version checking to correctly handle semantic versioning and pre-release comparisons when querying GitHub releases.

New Features:
- Support full SemVer 2.0.0 parsing including prerelease identifiers and build metadata in version comparison.

Bug Fixes:
- Fix version comparison failing for pre-release versions with the same core version by correctly ordering prerelease and stable releases.

Enhancements:
- Change GitHub release API endpoint to use the general releases list instead of only the latest release.
- Refine version comparison logic to distinguish numeric and alphanumeric prerelease identifiers according to SemVer rules.

Chores:
- Bump internal version number to v1.1.0-alpha.2.

</details>