### PR TITLE
feat(token): GitHub版本检查增加token来提高检查次数限制到5000次（目前做的配置项，没有写死）

### DIFF
--- a/src/lib/config.ahk
+++ b/src/lib/config.ahk
@@ -29,7 +29,8 @@ class Constants {
         "AutoOpenSettings", "自动打开设置界面",
         "Frame", "游戏内帧数设置",
         "AutoUpdate", "自动检查更新",
-        "LastDismissedVersion", "上次忽略的更新版本"
+        "LastDismissedVersion", "上次忽略的更新版本",
+        "GitHubToken", "GitHub Token"
     )
 }
 
@@ -90,7 +91,17 @@ class Config {
         
         ; 加载重要设置
         for keyVar, defaultVal in this._defaultImportant {
-            this._importantSettings[keyVar] := IniRead(this.IniFile, "Main", keyVar, defaultVal)
+            if (keyVar = "GitHubToken") {
+                ; Token需要解码
+                encodedToken := IniRead(this.IniFile, "Main", keyVar, defaultVal)
+                ; 调试输出
+                OutputDebug("[Config] Token读取 - INI中的值长度: " StrLen(encodedToken) ", 值: [" encodedToken "]")
+                decodedToken := this.DecodeToken(encodedToken)
+                OutputDebug("[Config] Token读取 - 解码后长度: " StrLen(decodedToken))
+                this._importantSettings[keyVar] := decodedToken
+            } else {
+                this._importantSettings[keyVar] := IniRead(this.IniFile, "Main", keyVar, defaultVal)
+            }
         }
         
         ; 如果配置文件不存在，创建并写入默认值
@@ -110,7 +121,14 @@ class Config {
         
         ; 写入所有默认重要设置
         for keyVar, defaultVal in this._defaultImportant {
-            IniWrite(defaultVal, this.IniFile, "Main", keyVar)
+            if (keyVar = "GitHubToken") {
+                ; Token需要编码存储，即使为空
+                encodedVal := this.EncodeToken(defaultVal)
+                OutputDebug("[Config] Token写入 - 默认值长度: " StrLen(defaultVal) ", 编码后长度: " StrLen(encodedVal))
+                IniWrite(encodedVal, this.IniFile, "Main", keyVar)
+            } else {
+                IniWrite(defaultVal, this.IniFile, "Main", keyVar)
+            }
         }
         
         ; 写入所有默认按键设置
@@ -134,7 +152,12 @@ class Config {
         ; 保存重要设置
         for keyVar, _ in Constants.ImportantNames {
             if settingsMap.HasProp(keyVar) {
-                IniWrite(settingsMap.%keyVar%, this.IniFile, "Main", keyVar)
+                if (keyVar = "GitHubToken") {
+                    ; Token需要编码存储
+                    IniWrite(this.EncodeToken(settingsMap.%keyVar%), this.IniFile, "Main", keyVar)
+                } else {
+                    IniWrite(settingsMap.%keyVar%, this.IniFile, "Main", keyVar)
+                }
             }
         }
         
@@ -154,7 +177,12 @@ class Config {
         
         ; 保存重要设置
         for keyVar, value in this._importantSettings {
-            IniWrite(value, this.IniFile, "Main", keyVar)
+            if (keyVar = "GitHubToken") {
+                ; Token需要编码存储
+                IniWrite(this.EncodeToken(value), this.IniFile, "Main", keyVar)
+            } else {
+                IniWrite(value, this.IniFile, "Main", keyVar)
+            }
         }
     }
     
@@ -193,7 +221,8 @@ class Config {
         "AutoOpenSettings", "1",
         "Frame", "3",
         "AutoUpdate", "1",
-        "LastDismissedVersion", ""
+        "LastDismissedVersion", "",
+        "GitHubToken", ""
     )
     
     ; 获取所有按键设置（用于遍历）
@@ -201,6 +230,18 @@ class Config {
     
     ; 获取所有重要设置（用于遍历）
     static AllImportant => this._importantSettings
+    
+    ; -- Token存储方法 --
+    
+    ; 编码Token（直接返回原文，不编码）
+    static EncodeToken(plainToken) {
+        return plainToken  ; 直接返回原文
+    }
+    
+    ; 解码Token（直接返回原文，不解码）
+    static DecodeToken(encodedToken) {
+        return encodedToken  ; 直接返回原文
+    }
 }
 
 ; -- 状态管理 --

--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -94,6 +94,13 @@ class GuiManager {
         this.GuiFrame := this.MainGui.Add("DropDownList", "x+12 y+-18 vFrame AltSubmit", ["30", "60", "120"])
         this.MainGui["Frame"].Value := Config.GetImportant("Frame")
         
+        ; GitHub Token设置
+        this.MainGui.Add("Text", "x30 y+18 w90 Right +0x200", "GitHub Token:")
+        this.MainGui.Add("Edit", "x+10 yp w380 vGitHubToken Password", Config.GetImportant("GitHubToken"))
+        this.MainGui.SetFont("s8 cGray")
+        this.MainGui.Add("Text", "x30 y+8 w480", "请使用无特殊权限的Classic Token以提高API请求配额")
+        this.MainGui.SetFont("s9 cDefault")
+        
         ; 提示语
         this.MainGui.SetFont("s9 c1b98d7")
         this.MainGui.Add("Text", "xm y+15 w" (this.GuiWidth - 30) " Center", "注: 请确保游戏内的按键为默认设置，点击输入框修改按键，使用ESC和退格键清除按键")

--- a/src/lib/key_bind.ahk
+++ b/src/lib/key_bind.ahk
@@ -37,6 +37,10 @@ WM_LBUTTONDOWN(wParam, lParam, msg, hwnd) {
         State.ControlObj := ""
     ; -- 如果点的是 Edit 控件 --
     if (State.ControlObj && State.ControlObj.Type == "Edit") {
+        ; 排除 GitHubToken 输入框（该控件用于文本输入，不是按键绑定）
+        if (State.ControlObj.Name == "GitHubToken") {
+            return
+        }
         ; 若为首次点击Edit控件
         if(State.LastEditObject == "") {
             ; 记录点击前的控件值，并修改值，以及记录本次点击

--- a/src/lib/settings/saver.ahk
+++ b/src/lib/settings/saver.ahk
@@ -20,6 +20,26 @@ HotkeyIniWrite() {
         }
     }
     
+    ; 验证GitHub Token（如果输入了的话）
+    if (SavedObj.HasProp("GitHubToken") && SavedObj.GitHubToken != "") {
+        ; 如果Token与当前保存的不同，需要验证
+        currentToken := Config.GetImportant("GitHubToken")
+        if (SavedObj.GitHubToken != currentToken) {
+            ; 验证新Token
+            tokenResult := VersionChecker.ValidateToken(SavedObj.GitHubToken)
+            if (!tokenResult.valid) {
+                result := MsgBox("GitHub Token验证失败：" tokenResult.message "`n`n是否仍要保存此Token？", "Token验证失败", "YesNo Icon!")
+                if (result = "No") {
+                    Exit
+                }
+            } else {
+                ; Token有效，更新验证状态
+                VersionChecker.TokenValidated := true
+                MsgBox("GitHub Token验证成功！`n用户: " tokenResult.username "`nAPI配额: " tokenResult.rateLimit, "Token有效", "Iconi")
+            }
+        }
+    }
+    
     ; 保存到INI
     Config.SaveToIni(SavedObj)
 }

--- a/src/lib/updater/updater.ahk
+++ b/src/lib/updater/updater.ahk
@@ -79,7 +79,19 @@ class Updater {
             
             case "rate_limited":
                 if (isManual) {
-                    UpdateUI.ShowCheckFailedDialog(checkResult.message)
+                    suggestToken := checkResult.HasProp("suggestToken") ? checkResult.suggestToken : false
+                    UpdateUI.ShowCheckFailedDialog(checkResult.message, suggestToken)
+                }
+            
+            case "token_invalid":
+                if (isManual) {
+                    ; Token无效，引导用户重新配置
+                    result := MsgBox(checkResult.message "`n`n是否现在修改Token设置？", "Token无效", "YesNo Icon!")
+                    if (result = "Yes") {
+                        ; 重置Token验证状态
+                        VersionChecker.TokenValidated := false
+                        GuiManager.Show()
+                    }
                 }
             
             case "check_failed":

--- a/src/lib/updater/updater_ui.ahk
+++ b/src/lib/updater/updater_ui.ahk
@@ -98,11 +98,21 @@ class UpdateUI {
     }
     
     ; 显示更新检查失败的提示
-    static ShowCheckFailedDialog(message := "") {
+    static ShowCheckFailedDialog(message := "", suggestToken := false) {
         if (message = "") {
             message := "检查更新失败，请检查网络连接后重试。"
         }
-        MsgBox(message, "检查失败", "Icon!")
+        
+        if (suggestToken) {
+            ; 显示带有Token配置引导的对话框
+            result := MsgBox(message "`n`n是否现在配置GitHub Token？", "检查失败", "YesNo Icon!")
+            if (result = "Yes") {
+                ; 打开设置界面
+                GuiManager.Show()
+            }
+        } else {
+            MsgBox(message, "检查失败", "Icon!")
+        }
     }
     
     ; 显示正在下载的提示

--- a/src/lib/updater/version_checker.ahk
+++ b/src/lib/updater/version_checker.ahk
@@ -4,13 +4,273 @@ class VersionChecker {
     ; GitHub API地址
     static ApiUrl := "https://api.github.com/repos/CloudTracey/arknights-frame-assistant/releases"
     
+    ; Token验证API地址
+    static TokenValidateUrl := "https://api.github.com/user"
+    
     ; 缓存文件路径
     static CacheFile := ""
+    
+    ; 超时设置（毫秒）
+    static TimeoutMs := 10000
+    
+    ; 是否启用调试日志（根据版本号判断，alpha版本启用）
+    static DebugMode := false
+    
+    ; Token验证状态缓存
+    static TokenValidated := false
     
     ; 初始化
     static Init() {
         configDir := A_AppData "\ArknightsFrameAssistant\PC"
         this.CacheFile := configDir "\version_cache.json"
+        
+        ; alpha版本启用调试模式
+        this.DebugMode := InStr(Version.Get(), "alpha") > 0
+    }
+    
+    ; 内部：输出调试日志
+    static _Log(message) {
+        if (this.DebugMode) {
+            OutputDebug("[VersionChecker] " message)
+        }
+    }
+    
+    ; 内部：输出请求报文日志
+    static _LogRequest(type, url, method, headers) {
+        if (!this.DebugMode)
+            return
+            
+        this._Log("========== " type " ==========")
+        this._Log("Timestamp: " this._Timestamp())
+        this._Log("Method: " method)
+        this._Log("URL: " url)
+        this._Log("Headers:")
+        for key, value in headers {
+            ; 隐藏敏感信息
+            if (key = "Authorization") {
+                ; 显示token前缀和长度，不显示完整token
+                tokenLen := StrLen(value) - 6  ; 减去 "token " 前缀长度
+                if (tokenLen > 0) {
+                    this._Log("  " key ": token ***" tokenLen "chars")
+                } else {
+                    this._Log("  " key ": " value)
+                }
+            } else {
+                this._Log("  " key ": " value)
+            }
+        }
+    }
+        
+    ; 内部：输出响应报文日志
+    static _LogResponse(type, statusCode, statusText, headers, body) {
+        if (!this.DebugMode)
+            return
+            
+        this._Log("========== " type " ==========")
+        this._Log("Timestamp: " this._Timestamp())
+        this._Log("Status: " statusCode " " statusText)
+        this._Log("Headers:")
+        if (headers != "") {
+            Loop Parse headers, "`n" {
+                this._Log("  " A_LoopField)
+            }
+        }
+        this._Log("Body (first 500 chars):")
+        this._Log(SubStr(body, 1, 500))
+    }
+    
+    ; 内部：格式化时间戳
+    static _Timestamp() {
+        return FormatTime(, "yyyy-MM-dd HH:mm:ss.") A_MSec
+    }
+    
+    ; 内部：构建HTTP请求对象
+    ; 返回: {http, error} - error非空表示创建失败
+    static _CreateHttpRequest(url, token := "") {
+        try {
+            http := ComObject("WinHttp.WinHttpRequest.5.1")
+            http.SetTimeouts(this.TimeoutMs, this.TimeoutMs, this.TimeoutMs, this.TimeoutMs)
+            http.Open("GET", url, false)
+            http.SetRequestHeader("Accept", "application/vnd.github.v3+json")
+            http.SetRequestHeader("User-Agent", "ArknightsFrameAssistant/" Version.Get())
+            if (token != "")
+                http.SetRequestHeader("Authorization", "token " token)
+            return {http: http, error: ""}
+        } catch as err {
+            return {http: "", error: err.Message}
+        }
+    }
+    
+    ; 内部：获取HTTP响应信息
+    static _GetResponseInfo(http) {
+        info := {statusCode: 0, statusText: "", headers: "", body: ""}
+        try
+            info.statusCode := http.Status
+        catch
+            {}
+        try
+            info.statusText := http.StatusText
+        catch
+            {}
+        try
+            info.headers := http.GetAllResponseHeaders()
+        catch
+            {}
+        try
+            info.body := http.ResponseText
+        catch
+            {}
+        return info
+    }
+    
+    ; 内部：获取Rate Limit信息
+    static _GetRateLimitInfo(http) {
+        remaining := "", limit := ""
+        try
+            remaining := http.GetResponseHeader("X-RateLimit-Remaining")
+        catch
+            {}
+        try
+            limit := http.GetResponseHeader("X-RateLimit-Limit")
+        catch
+            {}
+        return {remaining: remaining, limit: limit}
+    }
+    
+    ; 验证GitHub Token有效性
+    ; 返回: {valid, message, username, rateLimit}
+    static ValidateToken(token := "") {
+        if (token = "")
+            token := Config.GetImportant("GitHubToken")
+        
+        this._Log("========== 验证Token ==========")
+        this._Log("Token长度: " StrLen(token))
+        
+        ; 构建请求头Map（用于日志）
+        headersMap := Map(
+            "Accept", "application/vnd.github.v3+json",
+            "User-Agent", "ArknightsFrameAssistant/" Version.Get()
+        )
+        if (token != "")
+            headersMap["Authorization"] := "token ***" StrLen(token) "chars"
+        
+        this._LogRequest("TOKEN_VALIDATION_REQUEST", this.TokenValidateUrl, "GET", headersMap)
+        
+        try {
+            req := this._CreateHttpRequest(this.TokenValidateUrl, token)
+            if (req.error != "") {
+                this._Log("创建HTTP请求失败: " req.error)
+                return {valid: false, message: "网络错误: " req.error, username: "", rateLimit: ""}
+            }
+            
+            req.http.Send()
+            resp := this._GetResponseInfo(req.http)
+            rateInfo := this._GetRateLimitInfo(req.http)
+            
+            this._LogResponse("TOKEN_VALIDATION_RESPONSE", resp.statusCode, resp.statusText, resp.headers, resp.body)
+            
+            ; 解析结果
+            if (resp.statusCode = 200) {
+                username := this._ExtractJsonValue(resp.body, "login")
+                this.TokenValidated := true
+                this._Log("Token验证成功，用户: " username)
+                return {valid: true, message: "Token有效", username: username, rateLimit: rateInfo.remaining "/" rateInfo.limit}
+            } else if (resp.statusCode = 401) {
+                this.TokenValidated := false
+                this._Log("Token无效（401未授权）")
+                return {valid: false, message: "Token无效，请检查是否正确", username: "", rateLimit: ""}
+            } else if (resp.statusCode = 403) {
+                this.TokenValidated := false
+                this._Log("Token可能已超限（403禁止访问）")
+                return {valid: false, message: "API请求频率已超限", username: "", rateLimit: "0/" rateInfo.limit}
+            } else {
+                this.TokenValidated := false
+                this._Log("Token验证失败，状态码: " resp.statusCode)
+                return {valid: false, message: "验证失败，HTTP " resp.statusCode, username: "", rateLimit: ""}
+            }
+        } catch as err {
+            this.TokenValidated := false
+            errorInfo := this._ParseErrorInfo(err)
+            this._Log("Token验证异常: " errorInfo.desc)
+            return {valid: false, message: "网络错误: " errorInfo.desc, username: "", rateLimit: ""}
+        }
+    }
+    
+    ; 内部：解析网络错误码
+    static _ParseNetworkError(errorCode) {
+        ; WinHttp错误码解析
+        static ErrorMessages := Map(
+            0x80070057, "参数错误：请求参数无效",
+            0x80072EE7, "DNS解析失败：无法解析服务器域名",
+            0x80072EFD, "连接失败：无法连接到服务器",
+            0x80072EE2, "连接超时：服务器响应超时",
+            0x80072F06, "SSL证书错误：无法验证服务器身份",
+            0x80072F0D, "SSL证书无效：服务器证书不受信任",
+            0x80072F76, "SSL握手失败：无法建立安全连接",
+            0x80004005, "未知错误：请求失败"
+        )
+        
+        hexCode := Format("0x{:08X}", errorCode)
+        
+        ; 尝试匹配已知错误
+        if (ErrorMessages.Has(errorCode)) {
+            return {code: hexCode, desc: ErrorMessages[errorCode]}
+        }
+        
+        ; 检查是否为超时错误（0x80072EE2 是常见的超时错误）
+        if ((errorCode & 0xFFFF) = 0x2EE2) {
+            return {code: hexCode, desc: "请求超时：服务器未在规定时间内响应"}
+        }
+        
+        ; 通用网络错误
+        if ((errorCode & 0xFFFF0000) = 0x80070000) {
+            return {code: hexCode, desc: "网络错误：请求过程中发生错误"}
+        }
+        
+        return {code: hexCode, desc: "网络错误：未知错误类型"}
+    }
+    
+    ; 内部：解析错误对象信息（AHK v2 兼容）
+    static _ParseErrorInfo(err) {
+        ; 尝试从错误消息中解析HRESULT错误码
+        errMsg := err.Message
+        errorCode := 0
+        
+        ; 尝试匹配 0x开头的十六进制错误码
+        if (RegExMatch(errMsg, "i)0x[0-9A-Fa-f]{8}", &match)) {
+            try {
+                errorCode := Integer(match[0])
+            } catch {
+                errorCode := 0
+            }
+        }
+        
+        ; 如果没有从消息中解析到错误码，尝试使用 A_LastError
+        if (errorCode = 0 && A_LastError != 0) {
+            ; A_LastError 是 Win32 错误码，需要转换为 HRESULT
+            errorCode := 0x80070000 | A_LastError
+        }
+        
+        ; 如果解析到了错误码，使用网络错误解析
+        if (errorCode != 0) {
+            return this._ParseNetworkError(errorCode)
+        }
+        
+        ; 无法获取具体错误码，根据消息内容判断
+        desc := "网络错误："
+        if (InStr(errMsg, "timeout") || InStr(errMsg, "超时")) {
+            desc .= "请求超时"
+        } else if (InStr(errMsg, "DNS") || InStr(errMsg, "resolve")) {
+            desc .= "DNS解析失败"
+        } else if (InStr(errMsg, "SSL") || InStr(errMsg, "certificate")) {
+            desc .= "SSL证书错误"
+        } else if (InStr(errMsg, "connect") || InStr(errMsg, "连接")) {
+            desc .= "连接失败"
+        } else {
+            desc .= errMsg
+        }
+        
+        return {code: "N/A", desc: desc}
     }
     
     ; 检查更新（主入口）
@@ -18,56 +278,88 @@ class VersionChecker {
     static Check() {
         localVersion := Version.Get()
         
-        ; 直接从API获取最新版本（每次都检查）
+        ; 检查是否配置了Token
+        gitHubToken := Config.GetImportant("GitHubToken")
+        if (gitHubToken != "") {
+            ; 如果配置了Token，先验证Token有效性
+            if (!this.TokenValidated) {
+                tokenResult := this.ValidateToken(gitHubToken)
+                if (!tokenResult.valid) {
+                    this._Log("Token验证失败，阻止更新检查")
+                    return {status: "token_invalid", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: tokenResult.message "。请检查GitHub Token设置。"}
+                }
+            }
+        }
+        
+        ; 直接从API获取最新版本
         return this._FetchFromApi(localVersion)
     }
     
     ; 内部：从API获取最新版本
     static _FetchFromApi(localVersion) {
+        this._Log("========== 开始版本检查 ==========")
+        this._Log("Timestamp: " this._Timestamp())
+        this._Log("本地版本: [" localVersion "] 长度: " StrLen(localVersion))
+        this._Log("API URL: " this.ApiUrl)
+        this._Log("超时设置: " this.TimeoutMs "ms")
+        
+        ; 检查本地版本是否有效
+        if (localVersion = "") {
+            this._Log("错误: 本地版本为空!")
+            return {status: "check_failed", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: "无法获取本地版本号"}
+        }
+        
+        ; 获取Token
+        gitHubToken := Config.GetImportant("GitHubToken")
+        this._Log("GitHub Token长度: " StrLen(gitHubToken))
+        
+        ; 构建请求头Map（用于日志）
+        headersMap := Map(
+            "Accept", "application/vnd.github.v3+json",
+            "User-Agent", "ArknightsFrameAssistant/" localVersion
+        )
+        if (gitHubToken != "")
+            headersMap["Authorization"] := "token " gitHubToken
+        
+        this._LogRequest("VERSION_CHECK_REQUEST", this.ApiUrl, "GET", headersMap)
+        
         try {
-            ; 创建WinHttpRequest对象
-            http := ComObject("WinHttp.WinHttpRequest.5.1")
-            http.Open("GET", this.ApiUrl, false)
-            http.SetRequestHeader("Accept", "application/vnd.github.v3+json")
-            http.SetRequestHeader("User-Agent", "ArknightsFrameAssistant/" localVersion)
-            http.Send()
+            req := this._CreateHttpRequest(this.ApiUrl, gitHubToken)
+            if (req.error != "") {
+                this._Log("创建HTTP请求失败: " req.error)
+                return {status: "check_failed", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: "网络错误: " req.error}
+            }
+            
+            this._Log("发送请求...")
+            req.http.Send()
+            this._Log("请求已发送，等待响应...")
+            
+            resp := this._GetResponseInfo(req.http)
+            this._LogResponse("VERSION_CHECK_RESPONSE", resp.statusCode, resp.statusText, resp.headers, resp.body)
             
             ; 检查HTTP状态
-            statusCode := http.Status
-            if (statusCode = 403) {
-                return {
-                    status: "rate_limited",
-                    localVersion: localVersion,
-                    remoteVersion: "",
-                    downloadUrl: "",
-                    message: "API请求过于频繁，请稍后再试"
-                }
+            if (resp.statusCode = 401) {
+                this._Log("Token无效（401未授权）")
+                return {status: "token_invalid", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: "GitHub Token无效，请检查设置"}
             }
-            if (statusCode != 200) {
-                return {
-                    status: "check_failed",
-                    localVersion: localVersion,
-                    remoteVersion: "",
-                    downloadUrl: "",
-                    message: "服务器返回错误: " statusCode
-                }
+            if (resp.statusCode = 403) {
+                this._Log("检测到API频率限制")
+                return {status: "rate_limited", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: "API请求频率超限。请在设置中配置GitHub Token以提高配额", suggestToken: true}
+            }
+            if (resp.statusCode != 200) {
+                this._Log("服务器返回非200状态码: " resp.statusCode)
+                return {status: "check_failed", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: "服务器返回错误: " resp.statusCode " " resp.statusText}
             }
             
             ; 解析JSON响应
-            response := http.ResponseText
-            
-            ; 手动解析JSON
-            remoteVersion := this._ExtractJsonValue(response, "tag_name")
-            downloadUrl := this._ExtractJsonValue(response, "browser_download_url")
+            remoteVersion := this._ExtractJsonValue(resp.body, "tag_name")
+            downloadUrl := this._ExtractJsonValue(resp.body, "browser_download_url")
+            this._Log("解析结果 - 远程版本: " remoteVersion)
+            this._Log("解析结果 - 下载地址: " downloadUrl)
             
             if (remoteVersion = "" || downloadUrl = "") {
-                return {
-                    status: "check_failed",
-                    localVersion: localVersion,
-                    remoteVersion: "",
-                    downloadUrl: "",
-                    message: "无法解析版本信息"
-                }
+                this._Log("无法解析版本信息")
+                return {status: "check_failed", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: "无法解析版本信息"}
             }
             
             ; 保存到缓存
@@ -75,30 +367,28 @@ class VersionChecker {
             
             ; 比较版本
             compareResult := this._CompareVersions(localVersion, remoteVersion)
+            this._Log("版本比较结果: " compareResult " (-1=需更新, 0=相同, 1=本地更新)")
+            
             if (compareResult < 0) {
-                return {
-                    status: "update_available",
-                    localVersion: localVersion,
-                    remoteVersion: remoteVersion,
-                    downloadUrl: downloadUrl
-                }
+                this._Log("发现新版本: " remoteVersion)
+                return {status: "update_available", localVersion: localVersion, remoteVersion: remoteVersion, downloadUrl: downloadUrl}
             } else {
-                return {
-                    status: "up_to_date",
-                    localVersion: localVersion,
-                    remoteVersion: remoteVersion,
-                    downloadUrl: ""
-                }
+                this._Log("已是最新版本")
+                return {status: "up_to_date", localVersion: localVersion, remoteVersion: remoteVersion, downloadUrl: ""}
             }
-        } 
-        catch as err {
-            return {
-                status: "check_failed",
-                localVersion: localVersion,
-                remoteVersion: "",
-                downloadUrl: "",
-                message: "网络错误: " err.Message
-            }
+        } catch as err {
+            errorInfo := this._ParseErrorInfo(err)
+            this._Log("========== VERSION_CHECK_ERROR ==========")
+            this._Log("Timestamp: " this._Timestamp())
+            this._Log("ErrorCode: " errorInfo.code)
+            this._Log("ErrorDesc: " errorInfo.desc)
+            this._Log("ErrorMessage: " err.Message)
+            
+            userMessage := errorInfo.desc
+            if (InStr(errorInfo.desc, "超时"))
+                userMessage := "网络请求超时，请检查网络连接后重试。`n`n如果问题持续存在，请尝试配置GitHub Token。"
+            
+            return {status: "check_failed", localVersion: localVersion, remoteVersion: "", downloadUrl: "", message: userMessage, errorDetail: "[" errorInfo.code "] " err.Message}
         }
     }
     
@@ -133,7 +423,9 @@ class VersionChecker {
             if (!DirExist(cacheDir))
                 DirCreate(cacheDir)
             
-            json := '{"latestVersion":"' version '","downloadUrl":"' url '"}'
+            ; 使用Chr(34)构建JSON字符串，避免转义问题
+            q := Chr(34)  ; 双引号
+            json := "{" q "latestVersion" q ":" q version q "," q "downloadUrl" q ":" q url q "}"
             
             if (FileExist(this.CacheFile))
                 FileDelete(this.CacheFile)
@@ -292,14 +584,17 @@ class VersionChecker {
     
     ; 内部：从JSON字符串中提取字段值
     static _ExtractJsonValue(json, key) {
-        ; 匹配 "key":"value" 或 "key":value 格式
-        pattern := '"' key '":\s*"([^"]*)"'
+        ; 匹配 "key":"value" 格式
+        ; 使用Chr构建正则表达式避免引号问题
+        q := Chr(34)  ; 双引号
+        notQ := Chr(94) Chr(34)  ; [^"]
+        pattern := q key q ":\s*" q "([" notQ "]*)" q
         if (RegExMatch(json, pattern, &match)) {
             return match[1]
         }
         
         ; 尝试匹配数字
-        pattern := '"' key '":\s*(\d+)'
+        pattern := q key q ":\s*(\d+)"
         if (RegExMatch(json, pattern, &match)) {
             return match[1]
         }


### PR DESCRIPTION
建议大大直接写死一个或多个自己的token来提高到5000次 * N

## Summary by Sourcery

为更新检查添加可选的 GitHub 令牌支持，以提高 API 速率限制，并在出现速率限制或令牌问题时提供更清晰的反馈和指导。

新功能：
- 引入可配置的 GitHub 令牌支持用于版本检查，以提高 GitHub API 的速率限制。
- 添加用于输入和存储 GitHub 令牌的图形界面控件，包括验证和用户提示。
- 在 alpha 构建中，为版本检查和令牌验证请求提供详细的调试日志和错误解析。

增强改进：
- 优化更新错误处理，以区分令牌无效、被速率限制以及通用失败状态，并引导用户前往设置页面。
- 改进用于版本缓存处理和发布元数据提取的 JSON 构造和解析逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional GitHub token support to update checks to increase API rate limits and surface clearer feedback and guidance when rate limiting or token issues occur.

New Features:
- Introduce configurable GitHub token support for version checking to raise GitHub API rate limits.
- Add GUI controls for entering and storing a GitHub token, including validation and user prompts.
- Provide detailed debug logging and error parsing for version check and token validation requests in alpha builds.

Enhancements:
- Refine update error handling to distinguish token invalid, rate limited, and generic failure states and guide users to settings.
- Improve JSON construction and parsing for version cache handling and release metadata extraction.

</details>