### PR TITLE
chore: 修改release-please.yml的预发布标识

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -19,4 +19,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
           prerelease: true
-          prerelease-type: alpha
+          prerelease-type: beta


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

CI：
- 调整 release-please 配置，从强制使用 `alpha` 预发布类型改为依赖默认的预发布类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust release-please configuration to rely on the default prerelease type instead of forcing 'alpha'.

</details>