### PR TITLE
fix: 调整了DPI感知模式，修复了多显示器下涉及坐标的功能错位的问题

### DIFF
--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -31,8 +31,10 @@ ActionGameSpeed(ThisHotkey) {
 ; 前进33ms，由于波动，过帧间隔设置为30ms，避免一次过两帧
 Action33ms(ThisHotkey) {
     oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
-    if !IsMouseInClient()
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Pos := PauseButtonPosition()
     MouseGetPos &xpos, &ypos
     BlockInput "MouseMove"
@@ -57,8 +59,10 @@ Action33ms(ThisHotkey) {
 ; 前进166ms
 Action166ms(ThisHotkey) {
     oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
-    if !IsMouseInClient()
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Pos := PauseButtonPosition()
     MouseGetPos &xpos, &ypos
     BlockInput "MouseMove"
@@ -83,8 +87,10 @@ Action166ms(ThisHotkey) {
 ; 暂停选中
 ActionPauseSelect(ThisHotkey) {
     oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
-    if !IsMouseInClient()
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Pos := PauseButtonPosition()
     MouseGetPos &xpos, &ypos
     BlockInput "MouseMove"
@@ -127,37 +133,51 @@ ActionRetreat(ThisHotkey) {
 }
 ; 一键技能
 ActionOneClickSkill(ThisHotkey) {
-    if !IsMouseInClient()
+    oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Send "{RButton Down}"
     Send "{RButton Up}"
     USleep(50)
     Send "{e Down}"
     USleep(50)
     Send "{e Up}"
-    if InStr(ThisHotkey, "Wheel")
+    if InStr(ThisHotkey, "Wheel") {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     PureKeyWait(ThisHotkey)
+    DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
 }
 ; 一键撤退
 ActionOneClickRetreat(ThisHotkey) {
-    if !IsMouseInClient()
+    oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Send "{RButton Down}"
     Send "{RButton Up}"
     USleep(50)
     Send "{q Down}"
     USleep(50)
     Send "{q Up}"
-    if InStr(ThisHotkey, "Wheel")
+    if InStr(ThisHotkey, "Wheel") {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     PureKeyWait(ThisHotkey)
+    DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
 }
 ; 暂停技能
 ActionPauseSkill(ThisHotkey) {
     oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
-    if !IsMouseInClient()
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Pos := PauseButtonPosition()
     MouseGetPos &xpos, &ypos
     BlockInput "MouseMove"
@@ -186,8 +206,10 @@ ActionPauseSkill(ThisHotkey) {
 ; 暂停撤退
 ActionPauseRetreat(ThisHotkey) {
     oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
-    if !IsMouseInClient()
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Pos := PauseButtonPosition()
     MouseGetPos &xpos, &ypos
     BlockInput "MouseMove"
@@ -215,15 +237,20 @@ ActionPauseRetreat(ThisHotkey) {
 }
 ; 模拟鼠标左键点击
 LButtonClick(ThisHotkey) {
-    if !IsMouseInClient()
+    oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+    if !IsMouseInClient() {
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
+    }
     Send "{Lbutton Down}"
     if InStr(ThisHotkey, "Wheel") {
         Send "{LButton Up}"
+        DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
     }
     PureKeyWait(ThisHotkey)
     Send "{LButton Up}"
+    DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
 }
 
 ; == 工具函数 ==


### PR DESCRIPTION
## 描述
使用
```
oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
; 其它代码
DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
```
调整了DPI感知模式，修复了多显示器下涉及坐标的功能错位的问题

## 关联 Issue
fixes #58 

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feature）
- [x] Bug 修复（bugfix）
- [ ] 代码风格优化（formatting）
- [ ] 重构（refactor）
- [ ] 测试（test）
- [ ] 文档更新（documentation）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [x] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
无

## 额外说明
无

## Summary by Sourcery

错误修复：
- 通过临时更改线程的 DPI 感知上下文，修复在使用多显示器时，暂停和时间控制快捷键的鼠标与坐标处理不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect mouse and coordinate handling for pause and time-control hotkeys when using multiple monitors by temporarily changing the thread DPI awareness context.

</details>