### PR TITLE
fix: 将技能和撤退点击延迟限定为只能输入数字

### DIFF
--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -201,7 +201,7 @@ class GuiManager {
 
         ; - 高级设置 -
         sep4 := this.MainGui.Add("Text", "x" this.GuiXMargin " y+20 w" this.GuiWidth - 60 " h1 Backgroundd0d0d0 Center") ; 分割线
-        sep4txt := this.MainGui.Add("Text", "x" this.GuiXMargin " xs+50 y+-9 Center ca0a0a0", "  高级设置  ")
+        sep4txt := this.MainGui.Add("Text", "x" this.GuiXMargin " xs+50 y+-9 Center ca0a0a0", "  自定义设置  ")
         this.OtherSettingsControls.Push(sep4)
         this.OtherSettingsControls.Push(sep4txt)
         ; 技能和撤退点击延迟设置


### PR DESCRIPTION
## 描述

- fix: 将技能和撤退点击延迟限定为只能输入数字
- ui: 将高级设置修改为自定义设置

## 关联 Issue


## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feature）
- [x] Bug 修复（bugfix）
- [ ] 代码风格优化（formatting）
- [ ] 重构（refactor）
- [ ] 测试（test）
- [ ] 文档更新（documentation）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [x] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）

## 额外说明

## Summary by Sourcery

将技能与撤退点击延迟设置限制为仅接受数字输入，并调整相关高级设置界面的文案标签。

Bug Fixes:
- 将技能与撤退点击延迟配置字段限制为仅接受数值输入，以避免无效输入。

Enhancements:
- 将主界面中高级/自定义设置区域的 `"高级设置"` 区域标签重命名为 `"自定义设置"`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Constrain the skill and retreat click delay setting to numeric input and adjust the related advanced settings UI labeling.

Bug Fixes:
- Restrict the skill and retreat click delay configuration field to accept only numeric values to avoid invalid input.

Enhancements:
- Rename the "高级设置" section label to "自定义设置" in the advanced/custom settings area of the main GUI.

</details>