### PR TITLE
fix: 修复了技能和撤退点击延迟未能正确保存的问题

### DIFF
--- a/src/lib/config.ahk
+++ b/src/lib/config.ahk
@@ -207,8 +207,10 @@ class Config {
 
         ; 保存自定义设置
         for keyVar, _ in Constants.CustomNames {
+            if (keyVar = "SwitchHotkey")
+                continue
             if settingsMap.HasProp(keyVar) {
-                IniWrite(settingsMap.%keyVar%, this.IniFile, "Custom", keyVar)
+                this.SetCustom(keyVar, settingsMap.%keyVar%)
             }
         }
         for keyVar, _ in Constants.CustomNames {


### PR DESCRIPTION
## 描述
fix: 修复了技能和撤退点击延迟未能正确保存的问题

## 关联 Issue

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [ ] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [ ] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [ ] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [ ] 该 PR 目标分支为 `develop`
- [ ] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

确保在保存设置时，自定义配置值能够被正确持久化。

Bug Fixes:
- 修复自定义配置中“技能点击延迟”和“撤退点击延迟”设置无法正确保存的问题。

Enhancements:
- 通过通用的 `SetCustom` 辅助方法来保存自定义配置项，并在通用保存循环中跳过持久化 `SwitchHotkey` 条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure custom configuration values are persisted correctly when saving settings.

Bug Fixes:
- Fix skill and retreat click delay settings not being saved properly in the custom configuration.

Enhancements:
- Route saving of custom configuration entries through the common SetCustom helper and skip persisting the SwitchHotkey entry from the generic save loop.

</details>