### PR TITLE
ui: 为快捷按键单开一个标签页

### DIFF
--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -62,11 +62,11 @@ class GuiManager {
         ; 设置托盘菜单
         A_IconTip := "AFA`n热键已启用"
         A_TrayMenu.Delete
-        A_TrayMenu.Add("打开按键设置", (*) => this.Show())
+        A_TrayMenu.Add("打开设置界面", (*) => this.Show())
         A_TrayMenu.Add("启用/禁用热键", (*) => EventBus.Publish("SwitchHotkey"))
         A_TrayMenu.Add("重启小助手", (*) => Reload())
         A_TrayMenu.Add("退出", (*) => ExitApp())
-        A_TrayMenu.Default := "打开按键设置"
+        A_TrayMenu.Default := "打开设置界面"
 
         ; 根据设置决定是否自动显示
         if (Config.GetImportant("AutoOpenSettings") == "1") {
@@ -107,7 +107,7 @@ class GuiManager {
         this.MainGui.Add("Text", "x0 y25 w" this.GuiWidth " h1 Backgroundd0d0d0") ; 分割线
         
         ; -- 作战按键 --
-        ; 按键设置 - 左列
+        ; 作战按键 - 左列
         this.MainGui.Add("GroupBox", "x0 y35 w" this.ColWidth " h0 Section vKeybindLeftGroup", "")
         this.KeybindControls.Push(this.MainGui["KeybindLeftGroup"])
 
@@ -118,7 +118,7 @@ class GuiManager {
         this.KeybindControls.Push(AddBindRow("干员技能", "Skill")*)
         this.KeybindControls.Push(AddBindRow("干员撤退", "Retreat")*)
         
-        ; 按键设置 - 右列
+        ; 作战按键 - 右列
         this.MainGui.Add("GroupBox", "x" this.ColWidth " ys w" this.ColWidth  " h0 Section vKeybindRightGroup", "")
         this.KeybindControls.Push(this.MainGui["KeybindRightGroup"])
         
@@ -132,7 +132,7 @@ class GuiManager {
         placeholder1 := this.MainGui.Add("Text", "xs+45 y+-10 w90 h0 Right +0x200")
         this.KeybindControls.Push(placeholder1)
 
-        ; 按键设置提示语
+        ; 作战按键提示语
         this.MainGui.SetFont("s9 c1994d2")
         hint1 := this.MainGui.Add("Text", "x0 yp+40 w" this.GuiWidth " Center", "请确保游戏内的按键为默认设置，点击输入框修改按键，使用【BACKSPACE】清除按键")
         this.MainGui.SetFont("s9 cDefault")
@@ -165,7 +165,7 @@ class GuiManager {
         this.QuickControls.Push(AddBindRow("放弃行动", "CeaseOperations")*)
         this.QuickControls.Push(AddBindRow("基建快速收取", "Harvest")*)
         
-        ; 按键设置 - 右列
+        ; 快捷按键 - 右列
         this.MainGui.Add("GroupBox", "x" this.ColWidth " ys w" this.ColWidth  " h0 Section vQuickRightGroup", "")
         this.QuickControls.Push(this.MainGui["QuickRightGroup"])
         
@@ -176,7 +176,7 @@ class GuiManager {
         placeholder1 := this.MainGui.Add("Text", "xs+45 y+-10 w90 h0 Right +0x200")
         this.QuickControls.Push(placeholder1)
 
-        ; 按键设置提示语
+        ; 快捷按键提示语
         this.MainGui.SetFont("s9 c1994d2")
         hintQuick := this.MainGui.Add("Text", "x0 yp+40 w" this.GuiWidth " Center", "请确保游戏内的按键为默认设置，点击输入框修改按键，使用【BACKSPACE】清除按键")
         this.MainGui.SetFont("s9 cDefault")
@@ -271,7 +271,7 @@ class GuiManager {
         BtnX_Apply := this.GuiWidth - (this.BtnW * 2) - BtnMargin * 1 - 45
         BtnX_Cancel := this.GuiWidth - this.BtnW - 45
         
-        this.BtnDefaultHotkeys := this.MainGui.Add("Button", "x" BtnX_DefaultHotkeys " y+20 w" this.BtnW " h32", "重置按键") ; 仅在按键设置相关标签下显示
+        this.BtnDefaultHotkeys := this.MainGui.Add("Button", "x" BtnX_DefaultHotkeys " y+20 w" this.BtnW " h32", "重置按键") ; 仅在按键相关标签下显示
         this.BtnDefaultHotkeys.OnEvent("Click", (*) => EventBus.Publish("SettingsReset"))
         this.KeybindControls.Push(this.BtnDefaultHotkeys)
         this.QuickControls.Push(this.BtnDefaultHotkeys)

--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -16,14 +16,19 @@ class GuiManager {
     
     ; 窗口尺寸常量
     static GuiWidth := 720
+    static TabWidth := this.GuiWidth / 4
     static ColWidth := this.GuiWidth / 2
     static GuiXMargin := 30
     static BtnW := 100
 
     ; 存储不同标签页的控件
-    static KeybindControls := []      ; 按键设置相关控件
+    static KeybindControls := []      ; 作战按键相关控件
+    static QuickControls := [] ; 快捷按键相关控件
+    static StrongHoldProtocolControls := [] ; 卫戍协议相关控件
     static OtherSettingsControls := [] ; 其他设置相关控件
-    static TxtKeybind := ""           ; "按键设置"标签文本
+    static TxtKeybind := ""           ; "作战按键"标签文本
+    static TxtQuick := ""             ; "快捷按键"标签文本
+    static TxtStrongHoldProtocol := ""  ; "卫戍协议"标签文本
     static TxtOther := ""             ; "其他设置"标签文本
     static CurrentTab := ""    ; 当前显示的标签页
     
@@ -84,18 +89,24 @@ class GuiManager {
 
         ; 让text控件假装自己是tab控件
         this.MainGui.SetFont("s9")
-        this.TxtKeybind := this.MainGui.Add("Text", "x0 y5 h20 w" this.ColWidth " Center Section c1994d2", "按键设置")
-        TabKeybind := this.MainGui.Add("Text", "x0 y0 h25 w" this.ColWidth " Center BackgroundTrans")
-        this.TxtOther := this.MainGui.Add("Text", "ys h20 w" this.ColWidth " Center", "其他设置")
-        TabOther := this.MainGui.Add("Text", "x" this.GuiWidth / 2 " y0 h25 w" this.ColWidth " Center BackgroundTrans")
+        this.TxtKeybind := this.MainGui.Add("Text", "x0 y5 h20 w" this.TabWidth " Center Section c1994d2", "作战按键")
+        TabKeybind := this.MainGui.Add("Text", "xs y0 h25 w" this.TabWidth " Center BackgroundTrans")
+        this.TxtQuick := this.MainGui.Add("Text", "ys h20 w" this.TabWidth " Center Section", "快捷按键")
+        TabQuick := this.MainGui.Add("Text", "xs y0 h25 w" this.TabWidth " Center BackgroundTrans")
+        this.TxtStrongHoldProtocol := this.MainGui.Add("Text", "ys h20 w" this.TabWidth " Center Section", "卫戍协议")
+        TabStrongHoldProtocol := this.MainGui.Add("Text", "xs y0 h25 w" this.TabWidth " Center BackgroundTrans")
+        this.TxtOther := this.MainGui.Add("Text", "ys h20 w" this.TabWidth " Center Section", "其他设置")
+        TabOther := this.MainGui.Add("Text", "xs y0 h25 w" this.TabWidth " Center BackgroundTrans")
         ; 为标签添加点击事件
         TabKeybind.OnEvent("Click", (*) => this.SwitchTab("keyBind"))
+        TabQuick.OnEvent("Click", (*) => this.SwitchTab("quick"))
+        TabStrongHoldProtocol.OnEvent("Click", (*) => this.SwitchTab("strongHoldProtocol"))
         TabOther.OnEvent("Click", (*) => this.SwitchTab("other"))
 
-        this.TabIndicator := this.MainGui.Add("Text", "xs y23 w" this.ColWidth " h2 Background1994d2") ; 选中指示线
+        this.TabIndicator := this.MainGui.Add("Text", "xs y23 w" this.TabWidth " h2 Background1994d2") ; 选中指示线
         this.MainGui.Add("Text", "x0 y25 w" this.GuiWidth " h1 Backgroundd0d0d0") ; 分割线
         
-        ; -- 按键设置 --
+        ; -- 作战按键 --
         ; 按键设置 - 左列
         this.MainGui.Add("GroupBox", "x0 y35 w" this.ColWidth " h0 Section vKeybindLeftGroup", "")
         this.KeybindControls.Push(this.MainGui["KeybindLeftGroup"])
@@ -106,9 +117,6 @@ class GuiManager {
         this.KeybindControls.Push(AddBindRow("暂停选中", "PauseSelect")*)
         this.KeybindControls.Push(AddBindRow("干员技能", "Skill")*)
         this.KeybindControls.Push(AddBindRow("干员撤退", "Retreat")*)
-        this.KeybindControls.Push(AddBindRow("模拟左键点击", "LButtonClick")*)
-        this.KeybindControls.Push(AddBindRow("放弃行动", "CeaseOperations")*)
-        this.KeybindControls.Push(AddBindRow("基建快速收取", "Harvest")*)
         
         ; 按键设置 - 右列
         this.MainGui.Add("GroupBox", "x" this.ColWidth " ys w" this.ColWidth  " h0 Section vKeybindRightGroup", "")
@@ -120,9 +128,6 @@ class GuiManager {
         this.KeybindControls.Push(AddBindRow("一键撤退", "OneClickRetreat")*)
         this.KeybindControls.Push(AddBindRow("暂停技能", "PauseSkill")*)
         this.KeybindControls.Push(AddBindRow("暂停撤退", "PauseRetreat")*)
-        this.KeybindControls.Push(AddBindRow("跳过招募动画/剧情", "Skip")*)
-        this.KeybindControls.Push(AddBindRow("肉鸽收取道具", "CollectCollectibles")*)
-        this.KeybindControls.Push(AddBindRow("返回上级菜单", "Back")*)
         ; 空白占位
         placeholder1 := this.MainGui.Add("Text", "xs+45 y+-10 w90 h0 Right +0x200")
         this.KeybindControls.Push(placeholder1)
@@ -152,26 +157,32 @@ class GuiManager {
         this.MainGui.SetFont("s9 cDefault")
         this.KeybindControls.Push(hint3)
 
-        ; 底部按钮
-        BtnMargin := 15
-        BtnX_DefaultHotkeys := 45
-        BtnX_Save := this.GuiWidth - (this.BtnW * 3) - BtnMargin * 2 - 45
-        BtnX_Apply := this.GuiWidth - (this.BtnW * 2) - BtnMargin * 1 - 45
-        BtnX_Cancel := this.GuiWidth - this.BtnW - 45
-        
-        this.BtnDefaultHotkeys := this.MainGui.Add("Button", "x" BtnX_DefaultHotkeys " y+20 w" this.BtnW " h32", "重置按键") ; 仅在按键设置标签下显示
-        this.BtnDefaultHotkeys.OnEvent("Click", (*) => EventBus.Publish("SettingsReset"))
-        
-        this.BtnSave := this.MainGui.Add("Button", "x" BtnX_Save " yp w" this.BtnW " h32 Default", "保存并关闭")
-        this.BtnSave.OnEvent("Click", (*) => EventBus.Publish("SettingsSave"))
-        this.BtnApply := this.MainGui.Add("Button", "x" BtnX_Apply " yp w" this.BtnW " h32 Default", "应用设置")
-        this.BtnApply.OnEvent("Click", (*) => EventBus.Publish("SettingsApply"))
-        this.BtnCancel := this.MainGui.Add("Button", "x" BtnX_Cancel " yp w" this.BtnW " h32", "取消")
-        this.BtnCancel.OnEvent("Click", (*) => EventBus.Publish("SettingsCancel"))
-        this.KeybindControls.Push(this.BtnDefaultHotkeys)
+        ; -- 快捷按键 --
+        this.MainGui.Add("GroupBox", "x0 y35 w" this.ColWidth " h0 Section vQuickLeftGroup", "")
+        this.QuickControls.Push(this.MainGui["QuickLeftGroup"])
 
+        this.QuickControls.Push(AddBindRow("模拟左键点击", "LButtonClick")*)
+        this.QuickControls.Push(AddBindRow("放弃行动", "CeaseOperations")*)
+        this.QuickControls.Push(AddBindRow("基建快速收取", "Harvest")*)
+        
+        ; 按键设置 - 右列
+        this.MainGui.Add("GroupBox", "x" this.ColWidth " ys w" this.ColWidth  " h0 Section vQuickRightGroup", "")
+        this.QuickControls.Push(this.MainGui["QuickRightGroup"])
+        
+        this.QuickControls.Push(AddBindRow("跳过招募动画/剧情", "Skip")*)
+        this.QuickControls.Push(AddBindRow("肉鸽收取道具", "CollectCollectibles")*)
+        this.QuickControls.Push(AddBindRow("返回上级菜单", "Back")*)
         ; 空白占位
-        this.MainGui.Add("Text", "xm y+15 w1 h1")
+        placeholder1 := this.MainGui.Add("Text", "xs+45 y+-10 w90 h0 Right +0x200")
+        this.QuickControls.Push(placeholder1)
+
+        ; 按键设置提示语
+        this.MainGui.SetFont("s9 c1994d2")
+        hintQuick := this.MainGui.Add("Text", "x0 yp+40 w" this.GuiWidth " Center", "请确保游戏内的按键为默认设置，点击输入框修改按键，使用【BACKSPACE】清除按键")
+        this.MainGui.SetFont("s9 cDefault")
+        this.QuickControls.Push(hintQuick)
+
+        ; -- 卫戍协议 --
 
         ; -- 其他设置 --
         this.MainGui.Add("GroupBox", "x0 y45 w" this.ColWidth " h0 Section vOtherSettingsGroup", "")
@@ -252,6 +263,29 @@ class GuiManager {
         this.SwitchHotkey := this.MainGui.Add("Edit", "x+10 yp-4 w140 Center -TabStop Uppercase vSwitchHotkey", Config.GetCustom("SwitchHotkey"))
         this.OtherSettingsControls.Push(txtSwitchHotkey)
         this.OtherSettingsControls.Push(this.SwitchHotkey)
+        
+        ; -- 底部按钮 --
+        BtnMargin := 15
+        BtnX_DefaultHotkeys := 45
+        BtnX_Save := this.GuiWidth - (this.BtnW * 3) - BtnMargin * 2 - 45
+        BtnX_Apply := this.GuiWidth - (this.BtnW * 2) - BtnMargin * 1 - 45
+        BtnX_Cancel := this.GuiWidth - this.BtnW - 45
+        
+        this.BtnDefaultHotkeys := this.MainGui.Add("Button", "x" BtnX_DefaultHotkeys " y+20 w" this.BtnW " h32", "重置按键") ; 仅在按键设置相关标签下显示
+        this.BtnDefaultHotkeys.OnEvent("Click", (*) => EventBus.Publish("SettingsReset"))
+        this.KeybindControls.Push(this.BtnDefaultHotkeys)
+        this.QuickControls.Push(this.BtnDefaultHotkeys)
+        this.StrongHoldProtocolControls.Push(this.BtnDefaultHotkeys)
+        
+        this.BtnSave := this.MainGui.Add("Button", "x" BtnX_Save " yp w" this.BtnW " h32 Default", "保存并关闭")
+        this.BtnSave.OnEvent("Click", (*) => EventBus.Publish("SettingsSave"))
+        this.BtnApply := this.MainGui.Add("Button", "x" BtnX_Apply " yp w" this.BtnW " h32 Default", "应用设置")
+        this.BtnApply.OnEvent("Click", (*) => EventBus.Publish("SettingsApply"))
+        this.BtnCancel := this.MainGui.Add("Button", "x" BtnX_Cancel " yp w" this.BtnW " h32", "取消")
+        this.BtnCancel.OnEvent("Click", (*) => EventBus.Publish("SettingsCancel"))
+
+        ; 空白占位
+        this.MainGui.Add("Text", "xm y+15 w1 h1")
     }
     
     ; 内部：更新热键控件值（从配置）
@@ -350,55 +384,110 @@ class GuiManager {
             ctrl.Opt("+Disabled")
     }
 
+    ; 内部：隐藏所有标签页的控件
+    static _HideAllControls() {
+        for ctrl in this.KeybindControls {
+            if (IsObject(ctrl)) {
+                try ctrl.Visible := false
+            }
+        }
+        for ctrl in this.QuickControls {
+            if (IsObject(ctrl)) {
+                try ctrl.Visible := false
+            }
+        }
+        for ctrl in this.StrongHoldProtocolControls {
+            if (IsObject(ctrl)) {
+                try ctrl.Visible := false
+            }
+        }
+        for ctrl in this.OtherSettingsControls {
+            if (IsObject(ctrl)) {
+                try ctrl.Visible := false
+            }
+        }
+    }
+
+    ; 内部：显示指定控件组
+    static _ShowControls(controls) {
+        for ctrl in controls {
+            if (IsObject(ctrl)) {
+                try ctrl.Visible := true
+            }
+        }
+    }
+
     ; 切换标签页
     static SwitchTab(tabName) {
         if (tabName = this.CurrentTab)
             return
         this.CurrentTab := tabName
         
+        ; 首先隐藏所有标签页的控件
+        this._HideAllControls()
+        
+        ; 切换到作战按键页
         if (tabName = "keyBind") {
-            ; 切换到按键设置页
             ; 更新标签样式
             this.TxtKeybind.SetFont("c1994d2")  ; 蓝色（选中）
+            this.TxtQuick.SetFont("cDefault")   ; 默认色
+            this.TxtStrongHoldProtocol.SetFont("cDefault")  ; 默认色
             this.TxtOther.SetFont("cDefault")   ; 默认色
+            
             ; 移动指示线
-            this.TabIndicator.Move(0, 23)
+            this.TxtKeybind.GetPos(&x)
+            this.TabIndicator.Move(x, 23)
             
-            ; 显示按键设置控件
-            for ctrl in this.KeybindControls {
-                if (IsObject(ctrl)) {
-                    try ctrl.Visible := true
-                }
-            }
-            
-            ; 隐藏其他设置控件
-            for ctrl in this.OtherSettingsControls {
-                if (IsObject(ctrl)) {
-                    try ctrl.Visible := false
-                }
-            }
+            ; 显示作战按键控件
+            this._ShowControls(this.KeybindControls)
         }
-        else if (tabName = "other") {
-            ; 切换到其他设置页
+
+        ; 切换到快捷按键页
+        else if (tabName = "quick") {
             ; 更新标签样式
             this.TxtKeybind.SetFont("cDefault")  ; 默认色
-            this.TxtOther.SetFont("c1994d2")     ; 蓝色（选中）
-            ; 移动指示线
-            this.TabIndicator.Move(this.ColWidth, 23)
+            this.TxtQuick.SetFont("c1994d2")     ; 蓝色（选中）
+            this.TxtStrongHoldProtocol.SetFont("cDefault")  ; 默认色
+            this.TxtOther.SetFont("cDefault")    ; 默认色
             
-            ; 隐藏按键设置控件
-            for ctrl in this.KeybindControls {
-                if (IsObject(ctrl)) {
-                    try ctrl.Visible := false
-                }
-            }
+            ; 移动指示线
+            this.TxtQuick.GetPos(&x)
+            this.TabIndicator.Move(x, 23)
+            
+            ; 显示快捷按键控件
+            this._ShowControls(this.QuickControls)
+        }
+
+        ; 切换到卫戍协议页
+        else if (tabName = "strongHoldProtocol") {
+            ; 更新标签样式
+            this.TxtKeybind.SetFont("cDefault")  ; 默认色
+            this.TxtQuick.SetFont("cDefault")    ; 默认色
+            this.TxtStrongHoldProtocol.SetFont("c1994d2")  ; 蓝色（选中）
+            this.TxtOther.SetFont("cDefault")    ; 默认色
+            
+            ; 移动指示线
+            this.TxtStrongHoldProtocol.GetPos(&x)
+            this.TabIndicator.Move(x, 23)
+            
+            ; 显示卫戍协议控件
+            this._ShowControls(this.StrongHoldProtocolControls)
+        }
+
+        ; 切换到其他设置页
+        else if (tabName = "other") {
+            ; 更新标签样式
+            this.TxtKeybind.SetFont("cDefault")  ; 默认色
+            this.TxtQuick.SetFont("cDefault")    ; 默认色
+            this.TxtStrongHoldProtocol.SetFont("cDefault")  ; 默认色
+            this.TxtOther.SetFont("c1994d2")     ; 蓝色（选中）
+            
+            ; 移动指示线
+            this.TxtOther.GetPos(&x)
+            this.TabIndicator.Move(x, 23)
             
             ; 显示其他设置控件
-            for ctrl in this.OtherSettingsControls {
-                if (IsObject(ctrl)) {
-                    try ctrl.Visible := true
-                }
-            }
+            this._ShowControls(this.OtherSettingsControls)
         }
     }
 }


### PR DESCRIPTION
## 描述
ui: 为快捷按键单开一个标签页

## 关联 Issue
closes #88 

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [ ] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [x] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [x] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## 由 Sourcery 提供的摘要

将按键绑定界面拆分为多个标签页，并为快捷操作和未来的要塞协议设置添加专用标签页和控件组。

新增功能：
- 在主设置窗口中，为战斗按键绑定、快捷按键绑定和要塞协议设置引入独立的标签页。

改进：
- 优化标签页布局为等宽分段，并更新标签页文本，以更好地描述战斗和快捷按键绑定。
- 在所有与按键绑定相关的标签页中共享重置热键按钮，同时将保存/应用/取消控件保留在窗口底部。
- 将标签页内容的显示/隐藏逻辑集中到可复用的辅助方法中，以在切换标签页时管理控件的可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split the keybinding UI into multiple tabs and add dedicated tabs and control groups for quick actions and future stronghold protocol settings.

New Features:
- Introduce separate tabs for combat keybinds, quick keybinds, and stronghold protocol settings in the main settings window.

Enhancements:
- Refine tab layout to use equal-width segments and update tab labels to better describe combat and quick keybindings.
- Share the reset-hotkeys button across all keybinding-related tabs while keeping save/apply/cancel controls at the bottom of the window.
- Centralize show/hide logic for tab content into reusable helper methods to manage control visibility when switching tabs.

</details>