### PR TITLE
release v1.5.0-beta.3

### DIFF
--- a/src/lib/updater/downloader.ahk
+++ b/src/lib/updater/downloader.ahk
@@ -117,7 +117,7 @@ class UpdateDownloader {
         try {
             http := ComObject("MSXML2.ServerXMLHTTP.6.0")
             this.CurrentHttp := http
-            http.SetProxy(0)
+            ApplySystemProxy(http)
             http.Open("HEAD", this.DownloadUrl, true)
             http.Send()
             
@@ -187,7 +187,7 @@ class UpdateDownloader {
             try {
                 http := ComObject("MSXML2.ServerXMLHTTP.6.0")
                 this.CurrentHttp := http
-                http.SetProxy(0)
+                ApplySystemProxy(http)
                 http.Open("GET", this.DownloadUrl, true)
                 http.SetRequestHeader("User-Agent", "ArknightsFrameAssistant/" Version.Get())
                 http.Send()
@@ -280,7 +280,7 @@ class UpdateDownloader {
             }
             http := this.ChunkHttp
             this.CurrentHttp := http
-            http.SetProxy(0)
+            ApplySystemProxy(http)
             http.Open("GET", this.DownloadUrl, true)
             http.SetRequestHeader("Range", "bytes=" rangeStart "-" rangeEnd)
             http.Send()

--- a/src/lib/updater/version_checker.ahk
+++ b/src/lib/updater/version_checker.ahk
@@ -1,3 +1,32 @@
+; == 系统代理读取工具 ==
+; 从注册表读取 IE/WinINET 系统代理设置（Clash Verge / v2rayN 等代理软件均通过此配置），
+; 返回 ServerXMLHTTP.SetProxy(2, ...) 兼容的代理字符串。
+GetSystemProxyServer() {
+    try {
+        proxyEnable := RegRead("HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings", "ProxyEnable")
+        if (proxyEnable != 1)
+            return ""
+        proxyServer := RegRead("HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings", "ProxyServer")
+        if (proxyServer = "")
+            return ""
+        ; 含协议前缀时（如 "http=...;https=..."），将分号转空格以符合 ServerXMLHTTP 格式
+        if (InStr(proxyServer, "="))
+            proxyServer := StrReplace(proxyServer, ";", " ")
+        return proxyServer
+    } catch {
+        return ""
+    }
+}
+
+; 为 HTTP 请求对象应用系统代理：系统代理已启用 → SetProxy(2, ...)；未启用 → SetProxy(1) 直连
+ApplySystemProxy(http) {
+    proxyServer := GetSystemProxyServer()
+    if (proxyServer != "")
+        http.SetProxy(2, proxyServer)
+    else
+        http.SetProxy(1)
+}
+
 ; == 版本检查器 ==
 
 class VersionChecker {
@@ -92,7 +121,7 @@ class VersionChecker {
     static _CreateHttpRequest(url, token := "") {
         try {
             http := ComObject("MSXML2.ServerXMLHTTP.6.0")
-            http.SetProxy(0)
+            ApplySystemProxy(http)
             http.Open("GET", url, true)
             http.SetRequestHeader("Accept", "application/vnd.github.v3+json")
             http.SetRequestHeader("User-Agent", "ArknightsFrameAssistant/" Version.Get())

--- a/src/lib/updater/version_checker.ahk
+++ b/src/lib/updater/version_checker.ahk
@@ -18,13 +18,20 @@ GetSystemProxyServer() {
     }
 }
 
-; 为 HTTP 请求对象应用系统代理：系统代理已启用 → SetProxy(2, ...)；未启用 → SetProxy(1) 直连
+; 为 HTTP 请求对象应用系统代理：系统代理已启用 → SetProxy(2, ...)；未启用 → SetProxy(0) 回退到 WinHTTP 默认
 ApplySystemProxy(http) {
     proxyServer := GetSystemProxyServer()
-    if (proxyServer != "")
-        http.SetProxy(2, proxyServer)
-    else
-        http.SetProxy(1)
+    if (proxyServer != "") {
+        bypassList := ""
+        try {
+            bypassList := RegRead("HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings", "ProxyOverride")
+            if (bypassList != "")
+                bypassList := StrReplace(bypassList, ";", " ")
+        }
+        http.SetProxy(2, proxyServer, bypassList)
+    } else {
+        http.SetProxy(0)
+    }
 }
 
 ; == 版本检查器 ==

--- a/src/lib/version.ahk
+++ b/src/lib/version.ahk
@@ -2,7 +2,7 @@
 
 class Version {
     ; 当前版本号
-    static Number := "v1.5.0-beta.2"
+    static Number := "v1.5.0-beta.3"
     
     ; 获取版本号
     static Get() {


### PR DESCRIPTION
release v1.5.0-beta.3

## Summary by Sourcery

使更新器的网络行为与 Windows 系统代理设置保持一致，并将应用版本提升到 v1.5.0-beta.3。

增强功能：
- 新增工具，用于读取 Windows Internet Settings 的代理配置，并将其应用到更新器使用的 HTTP 请求对象上。
- 更新版本检查和更新下载请求，使其遵循系统代理和绕过列表，而不是强制使用直接连接。

日常维护：
- 将上报的应用版本更新为 v1.5.0-beta.3。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align updater networking with Windows system proxy settings and bump the application version to v1.5.0-beta.3.

Enhancements:
- Introduce utilities to read Windows Internet Settings proxy configuration and apply it to HTTP request objects used by the updater.
- Update version checking and update download requests to respect system proxy and bypass lists instead of forcing direct connections.

Chores:
- Update the reported application version to v1.5.0-beta.3.

</details>

增强内容：
- 添加辅助工具，用于读取 Windows Internet Settings 的代理配置，并将其应用到 HTTP 请求对象上。
- 更新版本检查和更新下载逻辑，使其在进行网络请求时遵循系统代理设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使更新器的网络行为与 Windows 系统代理设置保持一致，并将应用版本提升到 v1.5.0-beta.3。

增强功能：
- 新增工具，用于读取 Windows Internet Settings 的代理配置，并将其应用到更新器使用的 HTTP 请求对象上。
- 更新版本检查和更新下载请求，使其遵循系统代理和绕过列表，而不是强制使用直接连接。

日常维护：
- 将上报的应用版本更新为 v1.5.0-beta.3。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align updater networking with Windows system proxy settings and bump the application version to v1.5.0-beta.3.

Enhancements:
- Introduce utilities to read Windows Internet Settings proxy configuration and apply it to HTTP request objects used by the updater.
- Update version checking and update download requests to respect system proxy and bypass lists instead of forcing direct connections.

Chores:
- Update the reported application version to v1.5.0-beta.3.

</details>

</details>