### PR TITLE
Feat/touch click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ other/
 CLAUDE.md
 .superpowers/
 docs/superpowers
+win_docs/

--- a/src/lib/config.ahk
+++ b/src/lib/config.ahk
@@ -3,13 +3,13 @@
 ; -- 常量定义 --
 class Constants {
     ; 延迟常量
-    static Delay30 := 34      ; 30帧
-    static Delay60 := 17      ; 60帧  
-    static Delay90 := 12      ; 90帧
-    static Delay120 := 9      ; 120帧
-    static Delay144 := 7      ; 144帧  
-    static Delay165 := 7      ; 165帧
-    static Delay240 := 5      ; 240帧
+    static Delay30 := 40      ; 30帧
+    static Delay60 := 24      ; 60帧  
+    static Delay90 := 20      ; 90帧
+    static Delay120 := 18      ; 120帧
+    static Delay144 := 16      ; 144帧  
+    static Delay165 := 14      ; 165帧
+    static Delay240 := 10      ; 240帧
 
     ; 按键名称映射
     static KeyNames := Map(

--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -397,7 +397,7 @@ class GuiManager {
         EventBus.Subscribe("GuiUpdateImportantControls", (*) => this._UpdateImportantControlsFromConfig())
         EventBus.Subscribe("GuiUpdateCustomControls", (*) => this._UpdateCustomControlsFromConfig())
         EventBus.Subscribe("GuiHide", (*) => this.Hide())
-        EventBus.Subscribe("KeyBindFocusSave", (*) => this.FocusSaveButton())
+        EventBus.Subscribe("KeyBindFocusCancel", (*) => this.FocusCancelButton())
         EventBus.Subscribe("GuiHideStopHook", HandleGuiHideStopHook)
         EventBus.Subscribe("CheckUpdateComplete", (*) => this.OnCheckUpdateComplete())
         EventBus.Subscribe("CheckUpdateStart", (*) => this.OnCheckUpdateStart())
@@ -465,9 +465,9 @@ class GuiManager {
         }
     }
     
-    ; 聚焦保存按钮
-    static FocusSaveButton() {
-        this.BtnSave.Focus()
+    ; 聚焦取消按钮
+    static FocusCancelButton() {
+        this.BtnCancel.Focus()
     }
     
     ; 获取窗口名称（用于WinActive等）

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -73,14 +73,14 @@ ActionPauseSelect(ThisHotkey) {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
     }
-    Send "{Space Down}"
-    USleep(State.CurrentDelay)
-    Send "{LButton Down}"
-    Send "{LButton Up}"
-    Send "{ESC Down}"
-    USleep(50)
-    Send "{Space Up}"
-    Send "{ESC Up}"
+    PosL := PauseButtonPositionLeft()
+    PosR := PauseButtonPositionRight()
+    MouseGetPos &xpos, &ypos
+    TouchInjector.Tap(PosL.PBLX, PosL.PBLY)
+    TouchInjector.Tap(xpos, ypos)
+    TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
+    USleep(30)
+    MouseMove xpos, ypos
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
@@ -460,6 +460,20 @@ PauseButtonPosition() {
     PButtonY := wh * 0.0666
     return {PBX: PButtonX, PBY: PButtonY}
 }
+; 获取暂停按钮左半部分位置
+PauseButtonPositionLeft() {
+    WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
+    PButtonLX := ww * 0.925
+    PButtonLY := wh * 0.0666
+    return {PBLX: PButtonLX, PBLY: PButtonLY}
+}
+; 获取暂停按钮右半部分位置
+PauseButtonPositionRight() {
+    WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
+    PButtonRX := ww * 0.970
+    PButtonRY := wh * 0.0666
+    return {PBRX: PButtonRX, PBRY: PButtonRY}
+}
 ; 获取基建收取按钮位置
 HarvestButtonPosition() {
     WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
@@ -474,3 +488,9 @@ CollectButtonPosition() {
     PButtonY := wh * 0.7250
     return {PBX: PButtonX, PBY: PButtonY}
 }
+
+; == 工具类 ==
+#Include ./touch_injection.ahk
+; TouchInjector.Down(x, y) 按下
+; TouchInjector.Up(x, y) 松开
+; TouchInjector.Tap(x, y) 点击

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -153,17 +153,17 @@ ActionPauseSkill(ThisHotkey) {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
     }
-    Send "{Space Down}"
-    USleep(State.CurrentDelay)
-    Send "{LButton Down}"
-    Send "{LButton Up}"
-    Send "{ESC Down}"
+    PosL := PauseButtonPositionLeft()
+    PosR := PauseButtonPositionRight()
+    MouseGetPos &xpos, &ypos
+    TouchInjector.Tap(PosL.PBLX, PosL.PBLY)
+    TouchInjector.Tap(xpos, ypos)
+    TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
     USleep(State.ClickDelay)
     Send "{e Down}"
     USleep(50)
     Send "{e Up}"
-    Send "{Space Up}"
-    Send "{ESC Up}"
+    MouseMove xpos, ypos
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
@@ -178,17 +178,17 @@ ActionPauseRetreat(ThisHotkey) {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
     }
-    Send "{Space Down}"
-    USleep(State.CurrentDelay)
-    Send "{LButton Down}"
-    Send "{LButton Up}"
-    Send "{ESC Down}"
+    PosL := PauseButtonPositionLeft()
+    PosR := PauseButtonPositionRight()
+    MouseGetPos &xpos, &ypos
+    TouchInjector.Tap(PosL.PBLX, PosL.PBLY)
+    TouchInjector.Tap(xpos, ypos)
+    TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
     USleep(State.ClickDelay)
     Send "{q Down}"
     USleep(50)
     Send "{q Up}"
-    Send "{Space Up}"
-    Send "{ESC Up}"
+    MouseMove xpos, ypos
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -79,7 +79,7 @@ ActionPauseSelect(ThisHotkey) {
     TouchInjector.Tap(PosL.PBLX, PosL.PBLY)
     TouchInjector.Tap(xpos, ypos)
     TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
-    USleep(30)
+    USleep(State.CurrentDelay)
     MouseMove xpos, ypos
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -161,9 +161,10 @@ ActionPauseSkill(ThisHotkey) {
     TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
     USleep(State.ClickDelay)
     Send "{e Down}"
-    USleep(50)
-    Send "{e Up}"
+    USleep(State.CurrentDelay)
     MouseMove xpos, ypos
+    USleep(50 - State.CurrentDelay)
+    Send "{e Up}"
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
@@ -186,9 +187,10 @@ ActionPauseRetreat(ThisHotkey) {
     TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
     USleep(State.ClickDelay)
     Send "{q Down}"
-    USleep(50)
-    Send "{q Up}"
+    USleep(State.CurrentDelay)
     MouseMove xpos, ypos
+    USleep(50 - State.CurrentDelay)
+    Send "{q Up}"
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
         return
@@ -491,6 +493,3 @@ CollectButtonPosition() {
 
 ; == 工具类 ==
 #Include ./touch_injection.ahk
-; TouchInjector.Down(x, y) 按下
-; TouchInjector.Up(x, y) 松开
-; TouchInjector.Tap(x, y) 点击

--- a/src/lib/key_bind.ahk
+++ b/src/lib/key_bind.ahk
@@ -25,7 +25,7 @@ class KeyBinder {
         if(this.ModifyHook.InProgress) {
             this.ModifyHook.OnEnd := ""
             this.ModifyHook.Stop()
-            EventBus.Publish("KeyBindFocusSave")
+            EventBus.Publish("KeyBindFocusCancel")
         }
     }
 
@@ -57,7 +57,7 @@ class KeyBinder {
                 KeyBinder.ModifyHook.Stop()
             }
             KeyBinder.WaitingModify := false
-            EventBus.Publish("KeyBindFocusSave")
+            EventBus.Publish("KeyBindFocusCancel")
             return
         }
         ; 若有输入按键且不是鼠标左键
@@ -87,7 +87,7 @@ class KeyBinder {
         KeyBinder.WaitingModify := false
         KeyBinder.ReleaseKey :=  ""
         KeyBinder.StopHook()
-        EventBus.Publish("KeyBindFocusSave")
+        EventBus.Publish("KeyBindFocusCancel")
     }
 
     ; 格式化显示键值
@@ -330,7 +330,7 @@ WatchActiveWindow(){
             KeyBinder.WaitingModify := false
             ; 释放可能存在的Hook
             KeyBinder.StopHook()
-            EventBus.Publish("KeyBindFocusSave")
+            EventBus.Publish("KeyBindFocusCancel")
         }
     }
 }

--- a/src/lib/touch_injection.ahk
+++ b/src/lib/touch_injection.ahk
@@ -1,0 +1,109 @@
+PT_TOUCH := 2
+
+POINTER_FLAG_INRANGE    := 0x00000002
+POINTER_FLAG_INCONTACT  := 0x00000004
+POINTER_FLAG_DOWN       := 0x00010000
+POINTER_FLAG_UPDATE     := 0x00020000
+POINTER_FLAG_UP         := 0x00040000
+
+class TouchInjector {
+    static _Initialized := false
+    static _Down := false
+    static _LastX := 0
+    static _LastY := 0
+    static LastError := 0
+
+    static Init(maxCount := 3, feedbackMode := 1) {
+        result := DllCall("User32.dll\InitializeTouchInjection", "UInt", maxCount, "UInt", feedbackMode, "Int")
+        if (!result) {
+            this.LastError := A_LastError
+            return false
+        }
+        this._Initialized := true
+        this.LastError := 0
+        return true
+    }
+
+    static _WriteFields(buf, x, y, flags) {
+        NumPut("UInt", PT_TOUCH, buf, 0)
+        NumPut("UInt", 0, buf, 4)
+        NumPut("UInt", flags, buf, 12)
+        NumPut("Int", x, buf, 32)
+        NumPut("Int", y, buf, 36)
+        NumPut("UInt", 7, buf, 100)
+        NumPut("UInt", 90, buf, 136)
+        NumPut("UInt", 32000, buf, 140)
+        NumPut("Int", x-2, buf, 104)
+        NumPut("Int", y-2, buf, 108)
+        NumPut("Int", x+2, buf, 112)
+        NumPut("Int", y+2, buf, 116)
+    }
+
+    static _Inject(flags) {
+        buf := Buffer(144, 0)
+        this._WriteFields(buf, this._LastX, this._LastY, flags)
+        result := DllCall("User32.dll\InjectTouchInput", "UInt", 1, "Ptr", buf, "Int")
+        if (!result) {
+            this.LastError := A_LastError
+            return false
+        }
+        this.LastError := 0
+        return true
+    }
+
+    ; 解析坐标，省略则用鼠标位置
+    static _ResolveCoord(x?, y?) {
+        if (!IsSet(x) || !IsSet(y)) {
+            CoordMode("Mouse", "Screen")
+            MouseGetPos(&mx, &my)
+            if (!IsSet(x))
+                x := mx
+            if (!IsSet(y))
+                y := my
+        }
+        this._LastX := x
+        this._LastY := y
+    }
+
+    ; 按下
+    static Down(x?, y?) {
+        if (!this._Initialized) {
+            this.LastError := 87
+            return false
+        }
+        if (this._Down) {
+            this.LastError := 87
+            return false
+        }
+        this._ResolveCoord(x?, y?)
+        if (!this._Inject(POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT | POINTER_FLAG_DOWN))
+            return false
+        this._Down := true
+        return true
+    }
+
+    ; 抬起
+    static Up(x?, y?) {
+        if (!this._Initialized || !this._Down) {
+            this.LastError := 87
+            return false
+        }
+
+        this._ResolveCoord(x?, y?)
+        if (!this._Inject(POINTER_FLAG_INRANGE | POINTER_FLAG_INCONTACT | POINTER_FLAG_UPDATE))
+            return false
+        if (!this._Inject(POINTER_FLAG_UP))
+            return false
+        this._Down := false
+        return true
+    }
+
+    ; 点击
+    static Tap(x?, y?) {
+        if (!this.Down(x?, y?))
+            return false
+        return this.Up(x?, y?)
+    }
+}
+
+TouchInjector.Init(3, 1)

--- a/src/lib/touch_injection.ahk
+++ b/src/lib/touch_injection.ahk
@@ -54,7 +54,6 @@ class TouchInjector {
     ; 解析坐标，省略则用鼠标位置
     static _ResolveCoord(x?, y?) {
         if (!IsSet(x) || !IsSet(y)) {
-            CoordMode("Mouse", "Screen")
             MouseGetPos(&mx, &my)
             if (!IsSet(x))
                 x := mx
@@ -84,7 +83,7 @@ class TouchInjector {
 
     ; 抬起
     static Up(x?, y?) {
-        if (!this._Initialized || !this._Down) {
+        if (!this._Initialized) {
             this.LastError := 87
             return false
         }

--- a/src/lib/touch_injection.ahk
+++ b/src/lib/touch_injection.ahk
@@ -40,8 +40,13 @@ class TouchInjector {
     }
 
     static _Inject(flags) {
+        hwnd := WinExist("ahk_exe Arknights.exe")
+        pt := Buffer(8, 0)
+        NumPut("Int", this._LastX, pt, 0)
+        NumPut("Int", this._LastY, pt, 4)
+        DllCall("User32.dll\ClientToScreen", "Ptr", hwnd, "Ptr", pt)
         buf := Buffer(144, 0)
-        this._WriteFields(buf, this._LastX, this._LastY, flags)
+        this._WriteFields(buf, NumGet(pt, 0, "Int"), NumGet(pt, 4, "Int"), flags)
         result := DllCall("User32.dll\InjectTouchInput", "UInt", 1, "Ptr", buf, "Int")
         if (!result) {
             this.LastError := A_LastError


### PR DESCRIPTION
## 描述
将暂停选取优化为无缝，同步修改0帧技能和0帧撤退，简单修复一些问题

## 关联 Issue

closes #110  #129 

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [x] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [x] 代码风格优化（style）
- [x] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [x] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [ ] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

将与暂停相关的操作切换为使用触控注入，并改进 0 帧技能/撤退操作的时序。

New Features:
- 引入 `TouchInjector` 工具，用于为游戏窗口模拟触控输入。
- 在暂停、技能和撤退快捷键操作中，使用基于触控的点击来操作暂停按钮以及当前光标位置。

Bug Fixes:
- 调整暂停选择、0 帧技能和 0 帧撤退的行为，使其更加流畅并且时序正确。
- 确保在键位绑定修改流程结束或被取消时，焦点能返回到取消按钮。

Enhancements:
- 优化帧延迟常量，使其与常见刷新率下的实际帧时序更加一致。
- 添加辅助函数，以便针对暂停按钮的左半部分和右半部分进行更精确的输入处理。
- 清理 GUI 与键位绑定相关的事件名称和焦点辅助方法，使其意图更加清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch pause-related actions to use touch injection and improve timing for 0-frame skill/retreat operations.

New Features:
- Introduce a TouchInjector utility to simulate touch input for the game window.
- Use touch-based taps on the pause button and current cursor position for pause, skill, and retreat hotkey actions.

Bug Fixes:
- Adjust pause selection, 0-frame skill, and 0-frame retreat behavior to be seamless and correctly timed.
- Ensure keybinding modification flow returns focus to the cancel button when hooks end or are cancelled.

Enhancements:
- Refine frame delay constants to better align with actual frame timings across common refresh rates.
- Add helper functions to target the left and right halves of the pause button for more precise input handling.
- Clean up GUI and keybinding event names and focus helpers for clearer intent.

</details>