### PR TITLE
fix: 修复了暂停相关操作有一定概率抢鼠标的问题

### DIFF
--- a/src/lib/config.ahk
+++ b/src/lib/config.ahk
@@ -3,13 +3,13 @@
 ; -- 常量定义 --
 class Constants {
     ; 延迟常量
-    static Delay30 := 40      ; 30帧
-    static Delay60 := 24      ; 60帧  
-    static Delay90 := 20      ; 90帧
-    static Delay120 := 18      ; 120帧
-    static Delay144 := 16      ; 144帧  
-    static Delay165 := 14      ; 165帧
-    static Delay240 := 10      ; 240帧
+    static Delay30 := 34      ; 30帧
+    static Delay60 := 17      ; 60帧  
+    static Delay90 := 12      ; 90帧
+    static Delay120 := 9      ; 120帧
+    static Delay144 := 8      ; 144帧  
+    static Delay165 := 7      ; 165帧
+    static Delay240 := 5      ; 240帧
 
     ; 按键名称映射
     static KeyNames := Map(

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -79,7 +79,8 @@ ActionPauseSelect(ThisHotkey) {
     TouchInjector.Tap(PosL.PBLX, PosL.PBLY)
     TouchInjector.Tap(xpos, ypos)
     TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
-    USleep(State.CurrentDelay)
+    USleep(State.CurrentDelay * 1.5)
+    TouchInjector.Tap(xpos, ypos)
     MouseMove xpos, ypos
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -161,9 +162,10 @@ ActionPauseSkill(ThisHotkey) {
     TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
     USleep(State.ClickDelay)
     Send "{e Down}"
-    USleep(State.CurrentDelay)
+    USleep(Max(State.CurrentDelay * 1.5 - State.ClickDelay, 0))
+    TouchInjector.Tap(xpos, ypos)
     MouseMove xpos, ypos
-    USleep(50 - State.CurrentDelay)
+    USleep(50)
     Send "{e Up}"
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -187,9 +189,10 @@ ActionPauseRetreat(ThisHotkey) {
     TouchInjector.Tap(PosR.PBRX, PosR.PBRY)
     USleep(State.ClickDelay)
     Send "{q Down}"
-    USleep(State.CurrentDelay)
+    USleep(Max(State.CurrentDelay * 1.5 - State.ClickDelay, 0))
+    TouchInjector.Tap(xpos, ypos)
     MouseMove xpos, ypos
-    USleep(50 - State.CurrentDelay)
+    USleep(50)
     Send "{q Up}"
     if InStr(ThisHotkey, "Wheel") {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")

--- a/src/lib/touch_injection.ahk
+++ b/src/lib/touch_injection.ahk
@@ -108,6 +108,26 @@ class TouchInjector {
             return false
         return this.Up(x?, y?)
     }
+
+    ; 无按下移动
+    static Move(x?, y?) {
+        if (!this._Initialized) {
+            this.LastError := 87
+            return false
+        }
+
+        this._ResolveCoord(x?, y?)
+        if (!this._Inject(POINTER_FLAG_INRANGE | POINTER_FLAG_UPDATE))
+            return false
+        if (!this._Inject(POINTER_FLAG_UP))
+            return false
+        this._Down := false
+        return true
+    }
 }
 
+; == 初始化 ==
 TouchInjector.Init(3, 1)
+MouseGetPos &xpos, &ypos
+TouchInjector.Move(xpos, ypos)
+MouseMove xpos, ypos


### PR DESCRIPTION
fix: 修复了暂停相关操作有一定概率抢鼠标的问题
fix: 修复了启动AFA的首次暂停操作必定抢鼠标的问题

## 描述
<!-- 请详细描述此次修改的内容和目的，包括必要的背景信息 -->

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [ ] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [ ] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [ ] 该 PR 目标分支为 `develop`
- [ ] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

调整与暂停相关的触控注入与计时机制，以防止意外抢占鼠标焦点。

Bug 修复:
- 通过额外一次点击以及更新后的触控移动行为，在暂停操作后恢复光标位置，防止暂停操作抢占鼠标焦点。
- 通过在当前鼠标位置初始化触控注入并优化暂停时序延迟，修复 AFA 启动后第一次暂停总是抢占鼠标焦点的问题。

增强项:
- 调整基于帧的延迟常量，使其在多种刷新率下更好地匹配目标帧率。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust pause-related touch injection and timing to prevent unintended mouse focus stealing.

Bug Fixes:
- Prevent pause actions from stealing mouse focus by restoring the cursor position via an additional tap and updated touch move behavior.
- Fix first pause after starting AFA always stealing mouse focus by initializing touch injection at the current mouse position and refining pause timing delays.

Enhancements:
- Tune frame-based delay constants to better match target frame rates across multiple refresh rates.

</details>