### PR TITLE
feat: 添加开局暂停功能

### DIFF
--- a/src/lib/config.ahk
+++ b/src/lib/config.ahk
@@ -34,6 +34,7 @@ class Constants {
         "Harvest", "基建快速收取",
         "CollectCollectibles", "肉鸽收取道具",
         "SwitchView", "视角切换",
+        "BeginPause", "开局暂停",
         ; 卫戍协议按键
         "CheckEnemies", "查看敌人",
         "DispatchCenter", "调度中心",  ; 不知道舟里的调度中心指的是哪种调度中心，随便选了一个译名
@@ -103,6 +104,7 @@ class Config {
         "Harvest", "",
         "CollectCollectibles", "",
         "SwitchView", "",
+        "BeginPause", "",
         ; 卫戍协议按键
         "CheckEnemies", "w",
         "DispatchCenter", "a",

--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -180,7 +180,8 @@ class GuiManager {
         this.QuickControls.Push(AddBindRow("模拟左键点击", "LButtonClick")*)
         this.QuickControls.Push(AddBindRow("基建快速收取", "Harvest")*)
         this.QuickControls.Push(AddBindRow("放弃行动", "CeaseOperations")*)
-        
+        this.QuickControls.Push(AddBindRow("开局暂停", "BeginPause")*)
+
         ; 快捷操作 - 右列
         this.MainGui.Add("GroupBox", "x" this.ColWidth " ys w" this.ColWidth  " h0 Section vQuickRightGroup", "")
         this.QuickControls.Push(this.MainGui["QuickRightGroup"])

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -335,6 +335,30 @@ ActionSwitchView(ThisHotkey) {
     PureKeyWait(ThisHotkey)
     try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
 }
+; 开局暂停
+ActionBeginPause(ThisHotkey) {
+    try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+    if !IsMouseInClient() {
+        try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
+        return
+    }
+    PosC := PauseButtonPositionColor()
+    while(GetKeyState(ThisHotkey, "P")) {
+        if PixelSearch(&FoundX, &FoundY, PosC.PBCRX, PosC.PBY, PosC.PBCLX, PosC.PBY, 0xB5B2B2, 5)
+        {
+            Send "{ESC Down}"
+            USleep(50)
+            Send "{ESC Up}"
+            break
+        }
+    }
+    if InStr(ThisHotkey, "Wheel") {
+        try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
+        return
+    }
+    PureKeyWait(ThisHotkey)
+    try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
+}
 
 
 ; -- 卫戍协议 --
@@ -500,6 +524,14 @@ PauseButtonPositionRight() {
     PButtonRX := ww * 0.9650
     PButtonRY := wh * 0.0700
     return {PBRX: PButtonRX, PBRY: PButtonRY}
+}
+; 获取暂停按钮颜色识别位置
+PauseButtonPositionColor() {
+    WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
+    PButtonCLX := ww * 0.9396
+    PButtonCRX := ww * 0.9511
+    PButtonY := wh * 0.0700
+    return {PBCLX: PButtonCLX, PBCRX: PButtonCRX, PBY: PButtonY}
 }
 ; 获取基建收取按钮位置
 HarvestButtonPosition() {

--- a/src/lib/hotkey_control.ahk
+++ b/src/lib/hotkey_control.ahk
@@ -38,6 +38,7 @@ class HotkeyController {
         "Harvest", ActionHarvest,
         "CollectCollectibles", ActionCollectCollectibles,
         "SwitchView", ActionSwitchView,
+        "BeginPause", ActionBeginPause,
         "CheckEnemies", ActionCheckEnemies,
         "DispatchCenter", ActionDispatchCenter,
         "Freeze", ActionFreeze,
@@ -75,7 +76,8 @@ class HotkeyController {
         "Back", true,
         "Harvest", true,
         "CollectCollectibles", true,
-        "SwitchView", true
+        "SwitchView", true,
+        "BeginPause", true
     )
 
     static StrongHoldHotkeys := Map(


### PR DESCRIPTION
## 描述
feat: 添加开局暂停功能

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [x] 新功能（feat）
- [ ] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [ ] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

为游戏中的早期阶段暂停动作新增可配置的快捷键和图形界面控制。

新功能：
- 引入 `ActionBeginPause` 快捷键动作，根据暂停按钮的像素检测在开局时暂停游戏。
- 在快速控制 GUI 和配置映射中暴露 `BeginPause` 快捷键，供用户自行绑定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable hotkey and GUI control to trigger an early-stage pause action in-game.

New Features:
- Introduce an ActionBeginPause hotkey action that pauses the game at the start based on pause button pixel detection.
- Expose the BeginPause hotkey in the quick controls GUI and configuration mappings for user binding.

</details>