### PR TITLE
fix: 修复了开局暂停绑定大部分按键会导致崩溃的问题

### DIFF
--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -231,7 +231,8 @@ ActionBeginPause(ThisHotkey) {
         return
     }
     PosC := PauseButtonPositionColor()
-    while(GetKeyState(ThisHotkey, "P")) {
+    pureKey := RegExReplace(ThisHotkey, "^[~*$!^+#&<>()]+")
+    while(GetKeyState(pureKey, "P")) {
         if PixelSearch(&FoundX, &FoundY, PosC.PBCRX, PosC.PBY, PosC.PBCLX, PosC.PBY, 0xB5B2B2, 25)
         {
             Send "{ESC Down}"

--- a/src/lib/settings/saver.ahk
+++ b/src/lib/settings/saver.ahk
@@ -64,7 +64,7 @@ class Saver {
                        "Skill", "Retreat", "33ms", "166ms", "OneClickSkill",
                        "OneClickRetreat", "PauseSkill", "PauseRetreat",
                        "LButtonClick", "CeaseOperations", "Skip", "Back",
-                       "Harvest", "CollectCollectibles", "SwitchView"]
+                       "Harvest", "CollectCollectibles", "SwitchView", "BeginPause"]
 
         strongholdKeys := ["CheckEnemies", "DispatchCenter", "Freeze", "Refresh",
                           "Upgrade", "Sell", "Ready", "StrongHoldProtocolLButtonClick",


### PR DESCRIPTION
fix: 修复了开局暂停被排除在按键冲突检测之外的问题

## 描述
<!-- 请详细描述此次修改的内容和目的，包括必要的背景信息 -->

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [ ] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [ ] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

修复对 begin-pause 热键的处理，使其能够正确参与按键冲突检测，并避免在与多数修饰键绑定时发生崩溃。

Bug Fixes:
- 防止在 begin-pause 热键与带有修饰符前缀的按键组合绑定时引发的崩溃。
- 将 begin-pause 热键包含在可配置按键集合中，以便在检测按键绑定冲突时进行检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix handling of the begin-pause hotkey to participate correctly in key conflict detection and avoid crashes when bound with most modifier keys.

Bug Fixes:
- Prevent crashes caused by the begin-pause hotkey when it is bound with modifier-prefixed key combinations.
- Include the begin-pause hotkey in the set of configurable keys that are checked for binding conflicts.

</details>