### PR TITLE
Release v1.5.4

### DIFF
--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -231,7 +231,8 @@ ActionBeginPause(ThisHotkey) {
         return
     }
     PosC := PauseButtonPositionColor()
-    while(GetKeyState(ThisHotkey, "P")) {
+    pureKey := RegExReplace(ThisHotkey, "^[~*$!^+#&<>()]+")
+    while(GetKeyState(pureKey, "P")) {
         if PixelSearch(&FoundX, &FoundY, PosC.PBCRX, PosC.PBY, PosC.PBCLX, PosC.PBY, 0xB5B2B2, 25)
         {
             Send "{ESC Down}"

--- a/src/lib/settings/saver.ahk
+++ b/src/lib/settings/saver.ahk
@@ -64,7 +64,7 @@ class Saver {
                        "Skill", "Retreat", "33ms", "166ms", "OneClickSkill",
                        "OneClickRetreat", "PauseSkill", "PauseRetreat",
                        "LButtonClick", "CeaseOperations", "Skip", "Back",
-                       "Harvest", "CollectCollectibles", "SwitchView"]
+                       "Harvest", "CollectCollectibles", "SwitchView", "BeginPause"]
 
         strongholdKeys := ["CheckEnemies", "DispatchCenter", "Freeze", "Refresh",
                           "Upgrade", "Sell", "Ready", "StrongHoldProtocolLButtonClick",


### PR DESCRIPTION
Release v1.5.4

## Summary by Sourcery

调整热键暂停处理方式，并扩展新 BeginPause 操作的设置持久化。

Bug Fixes:
- 通过在检查按键状态时忽略修饰键前缀，确保暂停行为能够正确追踪物理热键状态。

Enhancements:
- 将 BeginPause 热键的配置与其他通用热键一起持久化保存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust hotkey pause handling and extend settings persistence for the new BeginPause action.

Bug Fixes:
- Ensure pause behavior correctly tracks physical hotkey state by ignoring modifier prefixes when checking key state.

Enhancements:
- Persist configuration for the BeginPause hotkey alongside other general hotkeys.

</details>