### PR TITLE
refactor(hotkey_actions): 回滚对返回上级菜单的修改

### DIFF
--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -392,6 +392,16 @@ ActionSkip(ThisHotkey) {
 }
 ; 返回上级菜单
 ActionBack(ThisHotkey) {
+    Send "{v Down}"
+    Send "{ESC Down}"
+    USleep(50)
+    Send "{v Up}"
+    Send "{ESC Up}"
+    if InStr(ThisHotkey, "Wheel")
+        return
+    PureKeyWait(ThisHotkey)
+}
+/* ActionBack(ThisHotkey) {
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -460,7 +470,7 @@ ActionBack(ThisHotkey) {
     }
     PureKeyWait(ThisHotkey)
     try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
-}
+} */
 ; 基建快速收取
 ActionHarvest(ThisHotkey) {
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
@@ -699,13 +709,13 @@ SpeedButtonPositionColor() {
     PButtonCDY := wh * 0.0870
     return {PBCLX: PButtonCLX, PBCRX: PButtonCRX, PBCUY: PButtonCUY, PBCDY: PButtonCDY}
 }
-; 获取返回按钮识别位置
+/* ; 获取返回按钮识别位置
 BackButtonPosition() {
     WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
     PButtonLX := ww * 0.0260, PButtonRX := ww * 0.0552
     PButtonUY := wh * 0.0462, PButtonDY := wh * 0.0574
     return {PBLX: PButtonLX, PBUY: PButtonUY, PBRX: PButtonRX, PBDY: PButtonDY}
-}
+} */
 ; 获取基建收取按钮位置
 HarvestButtonPosition() {
     WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"


### PR DESCRIPTION
回滚更改

## Summary by Sourcery

通过恢复到基础按键发送实现，并禁用 DPI/上下文感知的返回按钮检测逻辑，简化返回导航热键行为。

增强点：
- 用更简单的按键序列替代上下文感知的返回导航逻辑，以返回到上一级菜单。
- 通过注释掉实现来禁用返回按钮位置检测辅助工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the back navigation hotkey behavior by reverting to a basic key send implementation and disabling the DPI/context-aware back button detection logic.

Enhancements:
- Replace the context-aware back navigation logic with a simpler key press sequence for returning to the previous menu.
- Disable the back button position detection helper by commenting out its implementation.

</details>