### PR TITLE
fix(ci): 发布时同时更新两个渠道的 version.json，确保 changelog 完整

### DIFF
--- a/.github/scripts/build_version_json.py
+++ b/.github/scripts/build_version_json.py
@@ -7,10 +7,15 @@ same changelog data as the GitHub source.
 
 Falls back to downloading the existing version.json from COS when the releases
 file is unavailable.
+
+When --sync-both is set, both stable/version.json and beta/version.json are
+updated with the same full releases array, ensuring changelog consistency
+regardless of which channel the user selects in AFA.
 """
 import argparse
 import json
 import os
+import re
 import sys
 import tempfile
 
@@ -148,6 +153,53 @@ def upload_version_json(cos_client, bucket, channel, data):
                 pass
 
 
+def _version_key(tag):
+    """Convert a version tag (e.g. 'v1.5.7' or 'v1.5.7-beta1') into a
+    sortable tuple so that max() returns the semantically highest version.
+
+    Follows SemVer 2.0 precedence: a stable release sorts HIGHER than any
+    prerelease of the same major.minor.patch (1.5.7 > 1.5.7-beta1).
+    """
+    v = re.sub(r"^[vV]", "", tag)
+
+    # Split core version from optional prerelease suffix
+    if "-" in v:
+        core, pre = v.split("-", 1)
+        pre_parts = re.split(r"[.]", pre)
+        pre_key = []
+        for p in pre_parts:
+            try:
+                pre_key.append((0, int(p)))
+            except ValueError:
+                pre_key.append((1, p))
+        is_stable = 0  # prerelease → lower priority
+        pre_tuple = tuple(pre_key)
+    else:
+        core = v
+        is_stable = 1  # stable → higher priority
+        pre_tuple = ()
+
+    core_parts = [int(x) for x in core.split(".")]
+    while len(core_parts) < 3:
+        core_parts.append(0)
+
+    # (core, is_stable, prerelease) — is_stable=1 beats is_stable=0
+    return (tuple(core_parts), is_stable, pre_tuple)
+
+
+def _find_latest_for_channel(releases, channel):
+    """Return the latest release dict for *channel* ('stable' or 'beta').
+
+    *releases* is a list of dicts as returned by :func:`load_github_releases`.
+    Returns ``None`` when no release matches the channel.
+    """
+    want_prerelease = channel == "beta"
+    candidates = [r for r in releases if r.get("prerelease", False) == want_prerelease]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda r: _version_key(r.get("tag_name", "")))
+
+
 def load_github_releases(filepath):
     """Load releases from a JSONL file produced by `gh api --paginate --jq`.
 
@@ -171,6 +223,33 @@ def load_github_releases(filepath):
     return releases
 
 
+def _upload_for_channel(cos_client, bucket, channel, version, date, body, domain,
+                        github_releases, is_current):
+    """Build and upload version.json for a single channel.
+
+    When *is_current* is True this is the release being published right now;
+    its version/date/body is used as the authoritative top-level data.  When
+    False it is the *other* channel being synced — its top-level data comes
+    from the latest matching release found in *github_releases*.
+    """
+    data = build_version_json(
+        channel, version, date, body, domain, github_releases
+    )
+
+    if github_releases:
+        upload_version_json(cos_client, bucket, channel, data)
+    else:
+        # Fallback: merge with existing releases on COS
+        existing_releases = download_existing_releases(cos_client, bucket, channel)
+        existing_versions = {r["tag_name"] for r in existing_releases}
+        if version not in existing_versions:
+            data["releases"].extend(existing_releases)
+        upload_version_json(cos_client, bucket, channel, data)
+
+    tag = " (current)" if is_current else " (synced)"
+    print(f"version.json updated: {version} ({channel}){tag}")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Build and upload version.json")
     parser.add_argument("--channel", required=True, choices=["stable", "beta"])
@@ -192,6 +271,11 @@ def main():
         default=None,
         help="Path to JSONL file of all GitHub releases (from gh api --paginate --jq)",
     )
+    parser.add_argument(
+        "--sync-both",
+        action="store_true",
+        help="Also update the other channel's version.json with the same full releases array",
+    )
     args = parser.parse_args()
 
     # Read body from file if --body-file is provided, otherwise use --body directly
@@ -206,25 +290,39 @@ def main():
     if github_releases:
         print(f"Loaded {len(github_releases)} releases from {args.releases_file}")
 
-    data = build_version_json(
-        args.channel, args.version, args.date, body, args.domain, github_releases
-    )
-
     cos_client = get_cos_client()
     bucket = os.environ["COS_BUCKET"]
 
-    if github_releases:
-        # We already have full history from GitHub — upload directly
-        upload_version_json(cos_client, bucket, args.channel, data)
-    else:
-        # Fallback: merge with existing releases on COS
-        existing_releases = download_existing_releases(cos_client, bucket, args.channel)
-        existing_versions = {r["tag_name"] for r in existing_releases}
-        if args.version not in existing_versions:
-            data["releases"].extend(existing_releases)
-        upload_version_json(cos_client, bucket, args.channel, data)
+    # Always upload for the current (triggering) channel first
+    _upload_for_channel(
+        cos_client, bucket, args.channel, args.version, args.date, body,
+        args.domain, github_releases, is_current=True,
+    )
 
-    print(f"version.json updated: {args.version} ({args.channel})")
+    # Optionally sync the other channel so both version.json files carry the
+    # same full releases array — this keeps changelogs consistent regardless
+    # of which channel the user selects in AFA.
+    if args.sync_both:
+        other_channel = "beta" if args.channel == "stable" else "stable"
+        other_latest = _find_latest_for_channel(github_releases, other_channel)
+
+        if other_latest is not None:
+            other_version = other_latest.get("tag_name", "")
+            other_date = (other_latest.get("published_at", "") or "")[:10]
+            other_body = other_latest.get("body", "")
+            if other_version:
+                _upload_for_channel(
+                    cos_client, bucket, other_channel, other_version,
+                    other_date, other_body, args.domain, github_releases,
+                    is_current=False,
+                )
+            else:
+                print(f"Skipping {other_channel}: latest release has no tag_name")
+        else:
+            print(
+                f"Skipping {other_channel}: no releases found for that channel "
+                f"in GitHub API data"
+            )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -111,12 +111,13 @@ jobs:
             --date "$(date -d "$RELEASE_DATE_INPUT" +%Y-%m-%d)" \
             --body-file /tmp/release_body.txt \
             --domain "${{ secrets.CDN_DOMAIN }}" \
-            --releases-file /tmp/all_releases.jsonl
+            --releases-file /tmp/all_releases.jsonl \
+            --sync-both
 
       - name: Refresh CDN cache
         run: |
           tccli configure set secretId ${{ secrets.COS_SECRET_ID }}
           tccli configure set secretKey ${{ secrets.COS_SECRET_KEY }}
           tccli configure set region ${{ secrets.COS_REGION }}
-          CHANNEL="${{ steps.channel.outputs.name }}"
-          tccli cdn PurgePathCache --Paths "[\"https://${{ secrets.CDN_DOMAIN }}/${CHANNEL}/version.json\"]" --FlushType flush
+          DOMAIN="${{ secrets.CDN_DOMAIN }}"
+          tccli cdn PurgePathCache --Paths "[\"https://${DOMAIN}/stable/version.json\", \"https://${DOMAIN}/beta/version.json\"]" --FlushType flush


### PR DESCRIPTION
## 描述
新增 --sync-both 选项，任意渠道发布 release 时同步更新
stable/version.json 和 beta/version.json，两个文件共享相同的
全量 releases 数组，仅 top-level version/downloadUrl 反映各自 渠道的最新版。同时 CDN 缓存刷新两个渠道。

修复场景：选择测试版渠道但正式版更新时，或反之，更新公告只
显示所选渠道 version.json 的内容而缺失另一渠道的发布记录。

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [ ] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [x] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

在发布版本时新增对稳定版和测试版 `version.json` 文件的同步支持，以保持各渠道的变更日志一致。

New Features:
- 引入 `--sync-both` 选项，在发布版本时使用共享的版本历史同时更新稳定版和测试版的 `version.json` 文件。

Bug Fixes:
- 通过在任意发布渠道下都保持稳定版和测试版的 `version.json` 文件同步，确保发布公告展示完整的变更日志。

Enhancements:
- 将构建和上传 `version.json` 的逻辑重构为可复用的辅助函数，并加入语义化版本排序，以正确确定各渠道的最新发布版本。

CI:
- 更新 `release-sync` GitHub Actions 工作流以使用 `--sync-both`，并为稳定版和测试版的 `version.json` 路径刷新 CDN 缓存。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for synchronizing both stable and beta version.json files during release publishing to keep changelogs consistent across channels.

New Features:
- Introduce a --sync-both option to update both stable and beta version.json files with a shared releases history when publishing a release.

Bug Fixes:
- Ensure release announcements show a complete changelog by keeping stable and beta version.json files in sync regardless of the selected channel.

Enhancements:
- Refactor version.json building and uploading logic into reusable helpers and add semantic version ordering to correctly determine the latest release per channel.

CI:
- Update the release-sync GitHub Actions workflow to use --sync-both and refresh CDN caches for both stable and beta version.json paths.

</details>