### PR TITLE
fix(hotkey_actions): 暂时移除了关卡界面检测，避免因关卡UI变化以及跨显示屏导致特定功能失效

### DIFF
--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -2,9 +2,6 @@
 ; -- 常规作战 --
 ; 按下暂停
 ActionPressPause(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     Send "{ESC Down}"
     USleep(50)
     Send "{ESC Up}"
@@ -31,9 +28,6 @@ ActionGameSpeed(ThisHotkey) {
 }
 ; 前进16ms
 Action16ms(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -55,9 +49,6 @@ Action16ms(ThisHotkey) {
 }
 ; 前进33ms，由于波动，过帧间隔设置为30ms，避免一次过两帧
 Action33ms(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -79,9 +70,6 @@ Action33ms(ThisHotkey) {
 }
 ; 前进166ms
 Action166ms(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -103,9 +91,6 @@ Action166ms(ThisHotkey) {
 }
 ; 暂停选中
 ActionPauseSelect(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -147,9 +132,6 @@ ActionRetreat(ThisHotkey) {
 }
 ; 一键技能
 ActionOneClickSkill(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -170,9 +152,6 @@ ActionOneClickSkill(ThisHotkey) {
 }
 ; 一键撤退
 ActionOneClickRetreat(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -193,9 +172,6 @@ ActionOneClickRetreat(ThisHotkey) {
 }
 ; 暂停技能
 ActionPauseSkill(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -223,9 +199,6 @@ ActionPauseSkill(ThisHotkey) {
 }
 ; 暂停撤退
 ActionPauseRetreat(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -254,9 +227,6 @@ ActionPauseRetreat(ThisHotkey) {
 
 ; 视角切换
 ActionSwitchView(ThisHotkey) {
-    if !IsInLevel() {
-        return
-    }
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
     if !IsMouseInClient() {
         try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
@@ -320,18 +290,6 @@ ActionBeginPause() {
             ; 为了降低暂停延迟，后置代理指挥识别，识别到是代理指挥时取消暂停
             isProxy := false
             TobC := TakeOverButtonPositions()
-            ; 第一层：线点识别（精确，优先）
-            ; pointInfo := [] ; 调试代码
-            ; for point in TobC.LinePoints {
-            ;     if !PixelSearch(&FoundX, &FoundY, point.LX, point.Y, point.RX, point.Y, point.C, 20)
-            ;     {
-            ;         isProxy := false
-            ;         ; ToolTip("线点检测不通过：" . point.LX . " " . point.Y . "→" . point.RX . " " . point.Y . " " . Format("{1:X}", point.C) . " " . "实际识别到的：" . PixelGetColor(point.LX, point.Y))
-            ;         break
-            ;     }
-            ;     ; color := PixelGetColor(point.x, point.y)
-            ;     ; pointInfo.Push(Format("({:.0f},{:.0f})={:#x}", point.x, point.y, color)) ; 调试代码
-            ; }
             ; 接管代理按钮右侧边缘
             if ImageSearch(&OutputVarX, &OutputVarY, TobC.ImageRegion.RLX, TobC.ImageRegion.RUY, TobC.ImageRegion.RRX, TobC.ImageRegion.RDY, "*90 " FileExtractor.TakeOver1Path) or ImageSearch(&OutputVarX, &OutputVarY, TobC.ImageRegion.RLX, TobC.ImageRegion.RUY, TobC.ImageRegion.RRX, TobC.ImageRegion.RDY, "*90 " FileExtractor.TakeOver2Path) { ; 0 帧暂停接管按钮半透明导致至少需要 90 容错
                 isProxy := true
@@ -731,13 +689,6 @@ SpeedButtonPositionColor() {
     PButtonCDY := wh * 0.0870
     return {PBCLX: PButtonCLX, PBCRX: PButtonCRX, PBCUY: PButtonCUY, PBCDY: PButtonCDY}
 }
-/* ; 获取返回按钮识别位置
-BackButtonPosition() {
-    WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
-    PButtonLX := ww * 0.0260, PButtonRX := ww * 0.0552
-    PButtonUY := wh * 0.0462, PButtonDY := wh * 0.0574
-    return {PBLX: PButtonLX, PBUY: PButtonUY, PBRX: PButtonRX, PBDY: PButtonDY}
-} */
 ; 获取基建收取按钮位置
 HarvestButtonPosition() {
     WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
@@ -748,28 +699,6 @@ HarvestButtonPosition() {
 ; 获取代理接管作战按钮识别位置（线点识别 + 图像识别）
 TakeOverButtonPositions() {
     WinGetClientPos ,, &ww, &wh, "ahk_exe Arknights.exe"
-
-    ; ; === 线点识别坐标 ===
-    ; X1 := ww * 0.332031, X2 := ww * 0.336914, X3 := ww * 0.342285
-    ; X4 := ww * 0.347167, X5 := ww * 0.352539, X6 := ww * 0.357421
-    ; X7 := ww * 0.362792, X8 := ww * 0.367675, X9 := ww * 0.373046
-
-    ; UY  := wh * 0.887962  ; 上方 y
-    ; MY  := wh * 0.914814  ; 中线 y
-    ; DY  := wh * 0.939814  ; 下方 y
-
-    ; MColor := 0x333333  ; 中线识别颜色
-    ; BColor := 0x323232  ; 按钮背景颜色
-
-    ; LinePoints := [
-    ;     ; 线识别
-    ;     {LX : X2, RX : X8, Y: MY, C: MColor},
-    ;     ; 点识别
-    ;     {LX : X1, RX : X1, Y: DY, C: BColor}, {LX : X2, RX : X2, Y: DY, C: BColor}, {LX : X3, RX : X3, Y: DY, C: BColor},
-    ;     {LX : X4, RX : X4, Y: DY, C: BColor}, {LX : X5, RX : X5, Y: DY, C: BColor}, {LX : X6, RX : X6, Y: DY, C: BColor},
-    ;     {LX : X7, RX : X7, Y: DY, C: BColor}, {LX : X8, RX : X8, Y: DY, C: BColor}, {LX : X9, RX : X9, Y: DY, C: BColor}
-    ; ]
-
     ; === ImageSearch 搜索区域 ===
     ImageRegion := {
         ; 按钮右侧边缘
@@ -779,8 +708,6 @@ TakeOverButtonPositions() {
         HLX : ww * 0.2583, HRX : ww * 0.3354,
         HUY : wh * 0.9037, HDY : wh * 0.9620
     }
-
-    ; return {LinePoints: LinePoints, ImageRegion: ImageRegion}
     return {ImageRegion: ImageRegion}
 }
 ; 获取“收下”按钮位置


### PR DESCRIPTION
## 描述
暂时移除了关卡界面检测，避免因关卡UI变化以及跨显示屏导致特定功能失效

## 关联 Issue
fixes #197, fixes #198 

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

放宽热键操作中的关卡界面检测约束，以避免因界面变化或多显示器设置导致的功能失效。

Bug Fixes:
- 允许暂停、时间步进、技能、撤退、视角切换及相关热键在无需依赖可能因界面或显示设置变化而失效的关卡检测的情况下执行。

Enhancements:
- 通过仅依赖图像搜索并移除未使用的线点识别支撑逻辑，简化代理接管按钮的检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax level UI detection constraints in hotkey actions to avoid feature failures caused by UI changes or multi-display setups.

Bug Fixes:
- Allow pause, time-step, skill, retreat, view-switch, and related hotkeys to execute without relying on level detection that can break with UI or display changes.

Enhancements:
- Simplify proxy takeover button detection by relying only on image search and removing unused line-point recognition scaffolding.

</details>