### PR TITLE
fix(log_exporter, self_replacer): 格式修复

### DIFF
--- a/src/lib/log_exporter.ahk
+++ b/src/lib/log_exporter.ahk
@@ -45,7 +45,7 @@ class LogExporter {
             psStage := this._PowerShellQuote(staging)
             psZip := this._PowerShellQuote(tempZip)
             psCode := "Add-Type -AssemblyName System.IO.Compression.FileSystem; [IO.Compression.ZipFile]::CreateFromDirectory(" psStage "," psZip ",[IO.Compression.CompressionLevel]::Optimal,$false)"
-            command := "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command `"" psCode `""
+            command := "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command `"" psCode "`""
             exitCode := RunWait(command, A_ScriptDir, "Hide")
             if (exitCode != 0 || !FileExist(tempZip)) {
                 result.message := "压缩日志失败，PowerShell 返回码：" exitCode

--- a/src/lib/updater/self_replacer.ahk
+++ b/src/lib/updater/self_replacer.ahk
@@ -117,9 +117,9 @@ class SelfReplacer {
         lines.Push("chcp 65001 >nul")
         lines.Push("title AFA更新中...")
         ; 设置日志文件路径
-        lines.Push("set `"LOG_FILE=" logFile `"")
+        lines.Push("set `"LOG_FILE=" logFile "`"")
         ; 创建日志目录（如果不存在）
-        lines.Push("if not exist `"" logDirectory `"" mkdir `"" logDirectory `"")
+        lines.Push("if not exist `"" logDirectory "`" mkdir `"" logDirectory "`"")
         
         ; 获取当前exe文件名
         SplitPath(currentExePath, &currentExeName)


### PR DESCRIPTION
## 描述
格式修复

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [x] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

在更新程序批处理脚本和日志导出器的 PowerShell 命令中修正引号使用，确保日志路径和压缩命令按预期格式构建。

Bug 修复：
- 修复自更新程序脚本中的环境变量和目录创建命令，以便可靠地设置并创建日志路径。
- 修复日志导出器中的 PowerShell 命令构造方式，避免在压缩日志时生成格式错误的命令字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct quoting in updater batch script and log exporter PowerShell command to ensure log paths and compression commands are built with the intended format.

Bug Fixes:
- Fix environment variable and directory creation commands in the self updater script so log paths are set and created reliably.
- Fix PowerShell command construction in the log exporter to avoid malformed command strings when compressing logs.

</details>