### PR TITLE
fix(gui): 修复实时热键冲突反馈的三个UX问题

### DIFF
--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -15,6 +15,7 @@ class GuiManager {
     static SwitchHotkey := ""
     static IsModified := false
     static HasHotkeyConflicts := false
+    static _PrevConflictedControls := Map()  ; 上次冲突控件集合，用于增量字体更新
     static _InitialValues := Map()  ; 初始值快照，用于脏值对比
     static HintUnsaved := ""       ; 提示文字
     static IsOnStrongHoldProtocol := false
@@ -769,22 +770,31 @@ class GuiManager {
         }
     }
 
-    ; 重新计算冲突并标红所有冲突输入框。
+    ; 重新计算冲突并增量标红冲突输入框，避免全量控件闪烁。
     static RefreshHotkeyConflicts() {
         result := HotkeyConflictValidator.FindAll(
             Config.AllHotkeys,
             Config.AllCustom
         )
 
-        for controlName, _ in Config.AllHotkeys {
-            try this.MainGui[controlName].SetFont("cDefault")
-        }
-        try this.MainGui["SwitchHotkey"].SetFont("cDefault")
+        ; 构建本次冲突控件集合
+        newConflicted := Map()
+        for controlName, _ in result.ByControl
+            newConflicted[controlName] := true
 
-        for controlName, _ in result.ByControl {
-            try this.MainGui[controlName].SetFont("cD93025")
+        ; 仅恢复不再冲突的控件颜色
+        for controlName, _ in this._PrevConflictedControls {
+            if !newConflicted.Has(controlName)
+                try this.MainGui[controlName].SetFont("cDefault")
         }
 
+        ; 仅标红新增的冲突控件
+        for controlName, _ in newConflicted {
+            if !this._PrevConflictedControls.Has(controlName)
+                try this.MainGui[controlName].SetFont("cD93025")
+        }
+
+        this._PrevConflictedControls := newConflicted
         this.HasHotkeyConflicts := result.HasConflicts
         this.UpdateSaveButtonState()
     }
@@ -1065,20 +1075,28 @@ class GuiManager {
             result := MessageBox.Confirm("  修改尚未保存，确定离开此页面吗 ？","保存提示")
             if (result == "No")
                 return
+            ; 用户选择放弃修改，从 INI 重新加载以丢弃内存中所有未保存的值
+            Config.LoadFromIni()
         }
         this.CurrentTab := tabName
-        
+
         ; 记录最后选中的标签页（排除"其他设置"）
         if (tabName != "other") {
             this.LastActiveTab := tabName
         }
-        
+
+        ; 提前重置修改与冲突状态，确保 _UpdateTabUI 中 RefreshHotkeyConflicts
+        ; 触发时 IsModified 已为 false，避免提示文字闪现
+        this.SetIsModifiedFalse()
+        this.HasHotkeyConflicts := false
+
         ; 如果当前处于热键禁用状态，只更新UI，不切换热键
         if (!HotkeyController.HotkeyState) {
             this._UpdateTabUI(tabName)
+            this.CaptureInitialSnapshot()
             return
         }
-        
+
         ; 根据标签页切换热键组
         if (tabName = "keyBind" || tabName = "quick") {
             HotkeyController.EnableByTab("keyBind")
@@ -1097,12 +1115,9 @@ class GuiManager {
             }
         }
         ; "other"标签页不改变热键
-        
+
         ; 更新UI
         this._UpdateTabUI(tabName)
-
-        ; 将修改状态改回未修改，并刷新快照
-        this.SetIsModifiedFalse()
         this.CaptureInitialSnapshot()
     }
 


### PR DESCRIPTION
## 描述
- 切换标签页确认放弃修改后显式调用 LoadFromIni() 丢弃内存修改，修复切换到其他设置页后冲突提示残留且无法保存的问题
- 将 SetIsModifiedFalse 和 HasHotkeyConflicts 重置移到 _UpdateTabUI 之前，修复标签页切换时提示文字闪现的问题
- RefreshHotkeyConflicts 改为增量字体更新，仅对冲突状态变化的控件执行 SetFont，修复修改按键时热键控件闪烁的问题
- 补充遗漏的 CaptureInitialSnapshot 调用

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [x] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

在设置界面中改进快捷键冲突的用户体验，确保在切换标签页时状态一致，并减少冲突指示的视觉闪烁。

Bug 修复：
- 当用户确认离开已修改的标签页时，通过从 INI 重新加载配置来丢弃未保存的内存更改，防止过期的冲突警告和保存失败。
- 在更新标签页 UI 之前重置修改标记和快捷键冲突标记，从而在切换页面时不再出现未保存更改提示的闪烁。
- 将快捷键冲突高亮中的字体更新限制为冲突状态发生变化的控件，消除在编辑按键绑定时快捷键输入框不必要的闪烁。
- 确保在标签页 UI 更新之后（包括快捷键被禁用时）捕获初始值快照，使变更跟踪在标签页切换过程中保持准确。

增强功能：
- 追踪先前发生冲突的控件，以支持在 GUI 中对快捷键冲突样式进行增量更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve hotkey conflict UX in the settings GUI, ensuring consistent state when switching tabs and reducing visual flicker in conflict indicators.

Bug Fixes:
- Discard unsaved in-memory changes by reloading configuration from INI when the user confirms leaving a modified tab, preventing stale conflict warnings and save failures.
- Reset modification and hotkey conflict flags before updating the tab UI so that unsaved-change hints no longer flash when switching pages.
- Limit font updates in hotkey conflict highlighting to controls whose conflict state changed, eliminating unnecessary flicker in hotkey inputs when editing bindings.
- Ensure initial value snapshots are captured after tab UI updates, including when hotkeys are disabled, so change tracking remains accurate across tab switches.

Enhancements:
- Track previously conflicted controls to support incremental updates of hotkey conflict styling in the GUI.

</details>