### PR TITLE
fix(hotkey_control): 修复切换开局暂停热键失效的问题

### DIFF
--- a/src/lib/hotkey_control.ahk
+++ b/src/lib/hotkey_control.ahk
@@ -40,7 +40,7 @@ class HotkeyController {
         "Harvest", ActionHarvest,
         "CollectCollectibles", ActionCollectCollectibles,
         "SwitchView", ActionSwitchView,
-        "BeginPause", ActionBeginPause,
+        "BeginPause", ActionBeginPauseSwitch,
         "CheckEnemies", ActionCheckEnemies,
         "DispatchCenter", ActionDispatchCenter,
         "Freeze", ActionFreeze,

--- a/src/lib/version.ahk
+++ b/src/lib/version.ahk
@@ -2,7 +2,7 @@
 
 class Version {
     ; AFA当前版本号
-    static Number := "v1.5.11"
+    static Number := "v1.5.12"
     
     ; 获取版本号
     static Get() {


### PR DESCRIPTION
## 描述
修复切换开局暂停热键失效的问题

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [x] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

修复用于切换游戏开始/暂停的快捷键行为，并提升应用程序版本。

Bug 修复：
- 修正 `BeginPause` 快捷键的映射，使用合适的切换动作，使开始/暂停切换按预期工作。

杂项：
- 将应用程序版本标识从 `v1.5.11` 更新为 `v1.5.12`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the hotkey behavior for toggling game start/pause and bump the application version.

Bug Fixes:
- Correct the mapping for the BeginPause hotkey to use the appropriate toggle action so the start/pause switch works as expected.

Chores:
- Update the application version identifier from v1.5.11 to v1.5.12.

</details>