### PR TITLE
fix(gui): 修正开局自动暂停热键输入框变量名

### DIFF
--- a/src/lib/gui.ahk
+++ b/src/lib/gui.ahk
@@ -211,8 +211,8 @@ class GuiManager {
         checkboxAutoBeginPause.OnEvent("Click", (*) => this.TrackChange("AutoBeginPause"))
         this.MainGui["AutoBeginPause"].Value := Config.GetImportant("AutoBeginPause")
         this.NotOtherControls.Push(checkboxAutoBeginPause)
-        edit := this.MainGui.Add("Edit", "x+15 yp-4 w140 Center -TabStop Uppercase v" "AutoBeginPauseSwitch", Config.GetHotkey("AutoBeginPauseSwitch"))
-        this.NotOtherControls.Push(edit)
+        editAutoBeginPauseSwitch := this.MainGui.Add("Edit", "x+15 yp-4 w140 Center -TabStop Uppercase v" "AutoBeginPauseSwitch", Config.GetHotkey("AutoBeginPauseSwitch"))
+        this.NotOtherControls.Push(editAutoBeginPauseSwitch)
 
         ; 帧数设置提示语
         this.MainGui.SetFont("s9 c1994d2")


### PR DESCRIPTION
## 描述
修正开局自动暂停热键输入框局部变量名 `edit` -> `editAutoBeginPauseSwitch` ，符合变量作用

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [x] 单元测试已覆盖或无需覆盖
- [x] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

Enhancements:
- 通过使用更具描述性的局部变量名，提高自动开始暂停热键编辑控件的可读性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Improve readability of the auto-begin pause hotkey edit control by using a more descriptive local variable name.

</details>