### PR TITLE
Fix/is in level

### DIFF
--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -798,25 +798,6 @@ PauseButtonPositionLeft() {
     PButtonLY := wh * 0.0700
     return {PBLX: PButtonLX, PBLY: PButtonLY}
 }
-; 获取暂停按钮区域（左右界取 PauseButtonPositionLeft/Right，上下界在中心 0.07 上下各取 1.5% 高度）
-PauseButtonArea() {
-    if !SafeWinGetClientPos(&ww, &wh)
-        return false
-    LX := ww * 0.9400
-    RX := ww * 0.9650
-    UY := wh * 0.0550
-    DY := wh * 0.0850
-    return {LX: LX, RX: RX, UY: UY, DY: DY}
-}
-; 右上暂停按钮白色检测（守卫辅助条件：关卡内暂停按钮为白色，容差 20）
-PauseButtonWhite() {
-    PauseC := PauseButtonArea()
-    if !PauseC
-        return false
-    if PixelSearch(&FoundX, &FoundY, PauseC.RX, PauseC.UY, PauseC.LX, PauseC.DY, 0xffffff, 20)
-        return true
-    return false
-}
 ; 获取暂停按钮右半部分位置
 PauseButtonPositionRight() {
     if !SafeWinGetClientPos(&ww, &wh)

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -743,6 +743,7 @@ PureKeyWait(ThisHotkey) {
 ; 拦截是预期行为（非异常），用 Info 级别避免刷 critical 轨（WARN/ERROR 5 MiB 留给真正的问题）
 GuardInLevel(actionName, ThisHotkey) {
     try oldCtx := DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
+    ; 守卫判定：放弃按钮
     inLevel := IsInLevel()
     try DllCall("SetThreadDpiAwarenessContext", "ptr", oldCtx, "ptr")
     if inLevel
@@ -772,17 +773,17 @@ AbandonButtonPosition() {
     PButtonDY := wh * 0.0694
     return {PBLX: PButtonLX, PBUY: PButtonUY, PBRX: PButtonRX, PBDY: PButtonDY}
 }
-; 关卡界面检测
+; 关卡界面检测：只判定左上放弃按钮区域（灰色 0x8c8c8c / 生息演算黄色 0xd8d769，容差 20）
+; - 供 ActionBeginPause 二次确认使用：自动暂停时序下放弃按钮稳定可见，不受右上角按钮状态影响
+; - 守卫组合判定见 GuardInLevel（放弃按钮）
 IsInLevel() {
     AbdC := AbandonButtonPosition()
     if !AbdC
         return false
-    if PixelSearch(&FoundX, &FoundY, AbdC.PBRX, AbdC.PBDY, AbdC.PBLX, AbdC.PBUY, 0x8c8c8c, 0) {
+    if PixelSearch(&FoundX, &FoundY, AbdC.PBRX, AbdC.PBDY, AbdC.PBLX, AbdC.PBUY, 0x8c8c8c, 20)
         return true
-    }
-    if PixelSearch(&FoundX, &FoundY, AbdC.PBRX, AbdC.PBDY, AbdC.PBLX, AbdC.PBUY, 0xd8d769, 0) {
+    if PixelSearch(&FoundX, &FoundY, AbdC.PBRX, AbdC.PBDY, AbdC.PBLX, AbdC.PBUY, 0xd8d769, 20)
         return true
-    }
     return false
 }
 ; 获取暂停按钮位置
@@ -800,6 +801,25 @@ PauseButtonPositionLeft() {
     PButtonLX := ww * 0.9400
     PButtonLY := wh * 0.0700
     return {PBLX: PButtonLX, PBLY: PButtonLY}
+}
+; 获取暂停按钮区域（左右界取 PauseButtonPositionLeft/Right，上下界在中心 0.07 上下各取 1.5% 高度）
+PauseButtonArea() {
+    if !SafeWinGetClientPos(&ww, &wh)
+        return false
+    LX := ww * 0.9400
+    RX := ww * 0.9650
+    UY := wh * 0.0550
+    DY := wh * 0.0850
+    return {LX: LX, RX: RX, UY: UY, DY: DY}
+}
+; 右上暂停按钮白色检测（守卫辅助条件：关卡内暂停按钮为白色，容差 20）
+PauseButtonWhite() {
+    PauseC := PauseButtonArea()
+    if !PauseC
+        return false
+    if PixelSearch(&FoundX, &FoundY, PauseC.RX, PauseC.UY, PauseC.LX, PauseC.DY, 0xffffff, 20)
+        return true
+    return false
 }
 ; 获取暂停按钮右半部分位置
 PauseButtonPositionRight() {

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -875,7 +875,7 @@ SkipButtonPosition() {
     if !SafeWinGetClientPos(&ww, &wh)
         return false
     PButtonX := ww * 0.959765
-    PButtonY := wh * 0.091666
+    PButtonY := wh * 0.05
     return {PBX: PButtonX, PBY: PButtonY}
 }
 

--- a/src/lib/hotkey_actions.ahk
+++ b/src/lib/hotkey_actions.ahk
@@ -450,10 +450,8 @@ ActionLButtonClick(ThisHotkey) {
 ; 放弃行动
 ActionCeaseOperations(ThisHotkey) {
     GameKeys.SendDown("battleLeftPopup")
-    Send "{ESC Down}"
     USleep(50)
     GameKeys.SendUp("battleLeftPopup")
-    Send "{ESC Up}"
     if InStr(ThisHotkey, "Wheel")
         return
     PureKeyWait(ThisHotkey)
@@ -488,10 +486,8 @@ ActionSkip(ThisHotkey) {
 }
 ; 返回上级菜单
 ActionBack(ThisHotkey) {
-    GameKeys.SendDown("battleLeftPopup")
     Send "{ESC Down}"
     USleep(50)
-    GameKeys.SendUp("battleLeftPopup")
     Send "{ESC Up}"
     if InStr(ThisHotkey, "Wheel")
         return

--- a/src/lib/version.ahk
+++ b/src/lib/version.ahk
@@ -2,7 +2,7 @@
 
 class Version {
     ; AFA当前版本号
-    static Number := "v1.6.0"
+    static Number := "v1.6.1"
 
     ; 获取版本号
     static Get() {


### PR DESCRIPTION
## 描述
提高放弃作战按钮识别的容差，修复在部分设备上出现的作战按键、开局暂停完全失效的问题

## 关联 Issue
fixes #236 

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 请确认您的代码通过了以下测试 -->
- [x] 本地测试通过
- [ ] 单元测试已覆盖或无需覆盖
- [ ] 不影响现有功能
- [ ] 测试清单已包含在test目录下或已通过附件上传

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Summary by Sourcery

基于放弃和暂停按钮放宽关卡内守卫检测，以提高战斗界面中快捷键操作的可靠性，并提升应用版本号。

Bug Fixes:
- 增大在关卡界面检测放弃按钮时的颜色容差，以修复在某些设备上动作和自动暂停快捷键失效的问题。

Enhancements:
- 增加对暂停按钮区域/亮度的检查，作为辅助的关卡内守卫，以实现更稳健的战斗状态检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax in-level guard detection based on the abandon and pause buttons to improve reliability of hotkey actions in battle UIs, and bump the application version.

Bug Fixes:
- Increase color tolerance when detecting the abandon button in level screens to fix cases where action and auto-pause hotkeys failed on some devices.

Enhancements:
- Add pause button area/whiteness checks as auxiliary in-level guards for more robust battle state detection.

</details>