### PR TITLE
fix(hook_health): 消除长按 ~ 透传键的"未触发"误报

### DIFF
--- a/src/lib/core/diagnostics/hook_health.ahk
+++ b/src/lib/core/diagnostics/hook_health.ahk
@@ -24,6 +24,10 @@ class HookHealth {
     static MissWarnCooldownMs := 5000 ; 同键误报节流：记录"未触发"告警后，该键短时间内不再重复告警，
                                       ; 避免按住连打时按一次刷一条
     static MissThreshold := 3         ; 连续多少次未命中判定为钩子失效
+    static FireRaceWindowMs := 250    ; 按下沿与回调之间的竞态窗口：
+                                      ; 探针 100ms 轮询晚于钩子回调，按下瞬间回调可能先跑、
+                                      ; 探针后采样（档时快照已含本次回调计数），3000ms 后计数值不再
+                                      ; 增长而误判"未触发"。窗口内已回调的按下直接视为命中、不建档。
     static WatchRefreshMs := 5000     ; 监视键位表刷新间隔（纯内存，无 IO）
     static RecoverCooldownMs := 5000  ; 两次自愈之间的最小间隔，避免异常持续时反复重装钩子
     static AutoRecover := true        ; 已确认故障模式为钩子被系统摘除，默认开启自愈
@@ -35,6 +39,8 @@ class HookHealth {
     static _Pending := Map()          ; vk -> {tick, key, idleKbd, fire}
     static _FireByKey := Map()        ; pureKey -> 该键热键回调累计次数（NoteFire 递增）
     static _FireTotal := 0            ; 全部热键回调累计次数
+    static _LastFireTick := Map()     ; pureKey -> 该键最近一次回调时刻（按键隔离的命中判据，
+                                      ; 兼作按下沿竞态窗口判定）
     static _LastWarnTick := Map()     ; pureKey -> 该键最近一次"未触发告警"时刻（键级持久冷却，见 _ResolvePending）
     static _MissStreak := 0
     static _MissTotal := 0
@@ -69,6 +75,7 @@ class HookHealth {
             return
         this._FireTotal++
         this._FireByKey[pureKey] := this._FireByKey.Get(pureKey, 0) + 1
+        this._LastFireTick[pureKey] := A_TickCount
         ; 同键回调既然已经真实发生，立即结算并清掉该键挂起的按键，绝不误报为未触发
         this._ClearPendingFor(pureKey)
         if (this._Suspected)
@@ -143,6 +150,15 @@ class HookHealth {
             ; 新的物理按下沿：只在"本应触发热键"的条件下建档，避免误报
             if (!this._ShouldArm(pureKey))
                 continue
+            ; 按下-回调竞态窗口：探针 100ms 轮询必然晚于钩子回调。若本键刚发生过回调
+            ; （距现在 < FireRaceWindowMs），说明本次按下的回调已先于采样执行——
+            ; 此时快照计数已含本次回调，再建档会在宽限期后误判"未触发"——直接视为命中、不建档。
+            ; 钩子真正失效时 _LastFireTick 不会再有更新（历史时刻远早于按下沿，
+            ; 且按下后不会新增），本次按下正常建档、宽限后正常报 WARN，检测能力不受影响；
+            ; ~ 透传键（无 Up 变体、松开无回调）正是靠本逻辑消除误报。
+            lastFire := this._LastFireTick.Get(pureKey, 0)
+            if (lastFire != 0 && now - lastFire < this.FireRaceWindowMs)
+                continue
             ; 记录按下瞬间的 idleKbd 备查。注意：钩子未安装时 A_TimeIdleKeyboard 会退化为 A_TimeIdle，
             ; 纯键盘输入下两种情况数值都接近 0，故**不能单看此值判定钩子存活**，
             ; 真正的判据是快照里 idle/idleKbd/idlePhys 三值是否恒等。
@@ -194,7 +210,7 @@ class HookHealth {
             this._MissStreak++
             Logger.Warn("HookHealth", "物理按下未触发热键：key=" info.key
                 . "，按下瞬间 idleKbd=" info.idleKbd "ms"
-                . "，监听 " this.PendingGraceMs "ms 内无对应回调（若随后看到该键的 Action 执行日志，则本条为误报，可忽略）"
+                . "，监听 " this.PendingGraceMs "ms 内无对应回调"
                 . "，连续未命中=" this._MissStreak "，累计=" this._MissTotal)
             if (this._MissStreak >= this.MissThreshold)
                 this._OnSuspected()

--- a/src/lib/core/diagnostics/hook_health.ahk
+++ b/src/lib/core/diagnostics/hook_health.ahk
@@ -41,6 +41,9 @@ class HookHealth {
     static _FireTotal := 0            ; 全部热键回调累计次数
     static _LastFireTick := Map()     ; pureKey -> 该键最近一次回调时刻（按键隔离的命中判据，
                                       ; 兼作按下沿竞态窗口判定）
+    static _LastPressEdge := Map()    ; pureKey -> 该键最近一次**按下沿被采样到**的时刻。
+                                      ; 竞态判定用它区分"回调属于本次按下还是上一次按下"——
+                                      ; 快速连按（<250ms）时上一次的回调不应抑制本次建档
     static _LastWarnTick := Map()     ; pureKey -> 该键最近一次"未触发告警"时刻（键级持久冷却，见 _ResolvePending）
     static _MissStreak := 0
     static _MissTotal := 0
@@ -153,11 +156,18 @@ class HookHealth {
             ; 按下-回调竞态窗口：探针 100ms 轮询必然晚于钩子回调。若本键刚发生过回调
             ; （距现在 < FireRaceWindowMs），说明本次按下的回调已先于采样执行——
             ; 此时快照计数已含本次回调，再建档会在宽限期后误判"未触发"——直接视为命中、不建档。
-            ; 钩子真正失效时 _LastFireTick 不会再有更新（历史时刻远早于按下沿，
-            ; 且按下后不会新增），本次按下正常建档、宽限后正常报 WARN，检测能力不受影响；
+            ; 判定必须双重限定，缺一不可：
+            ;   (a) 回调时刻晚于**上一次**按下沿（_LastPressEdge）——否则它属于上一次按下，
+            ;       快速连按时会把这个"上一次的回调"误当成"本次按下的证据"，
+            ;       钩子在 250ms 内失效时本次按下将被漏检（审查 PR #351 指出的正确缺陷）；
+            ;   (b) now - 回调 < 竞态窗口——正常一次按键按-回调间隔在 100ms 采样内。
+            ; 钩子真正失效时 _LastFireTick 冻结在失效前（不会晚于本次按下沿），
+            ; 本次按下正常建档、宽限后正常报 WARN，检测能力不受影响；
             ; ~ 透传键（无 Up 变体、松开无回调）正是靠本逻辑消除误报。
+            prevEdge := this._LastPressEdge.Get(pureKey, 0)
+            this._LastPressEdge[pureKey] := now
             lastFire := this._LastFireTick.Get(pureKey, 0)
-            if (lastFire != 0 && now - lastFire < this.FireRaceWindowMs)
+            if (lastFire != 0 && lastFire > prevEdge && now - lastFire < this.FireRaceWindowMs)
                 continue
             ; 记录按下瞬间的 idleKbd 备查。注意：钩子未安装时 A_TimeIdleKeyboard 会退化为 A_TimeIdle，
             ; 纯键盘输入下两种情况数值都接近 0，故**不能单看此值判定钩子存活**，


### PR DESCRIPTION
## 描述
<!-- 请详细描述此次修改的内容和目的，包括必要的背景信息 -->
消除长按 ~ 透传键的"未触发"误报

## 关联 Issue
<!-- 如果该 PR 解决了某个 Issue，请在此填写 Issue 编号（如 "fixes #123"） -->

## 变更类型
<!-- 请在对应的选项前 [ ] 中填写 x，例如 [x] 新功能。测试清单随代码提交时类型为 docs、scope 为 test，如 docs(test): 添加 xxx 测试清单 -->
- [ ] 新功能（feat）
- [x] Bug 修复（fix）
- [ ] 文档更新（docs）
- [ ] 代码风格优化（style）
- [ ] 重构（refactor）
- [ ] 性能优化（perf）
- [ ] 测试（test）
- [ ] 构建过程或辅助工具的变动（chore）
- [ ] GUI相关修改（ui）
- [ ] 其他，请描述：

## 测试清单
<!-- 本项目没有自动化测试框架，所有测试为手工验证。请按 test/template/test_template.md 创建测试清单 -->
- [ ] 已按 test/template/test_template.md 完成手工测试验证
- [ ] 测试清单已创建于 test/ 目录（test_[主题].md），或已通过附件上传
- [x] 不影响现有功能

## 检查项
<!-- 在提交 PR 前，请确认以下事项 -->
- [x] 我已阅读并确认了CONTRIBUTING.md
- [x] 我的代码遵循了本项目的代码规范
- [ ] 我已经更新了相关文档（如有需要）
- [x] 该 PR 目标分支为 `develop`
- [x] 该 PR 不包含敏感信息（如密钥、密码等）

## 截图（可选）
<!-- 如果改动涉及 UI 或界面变化，请提供前后对比截图 -->

## 额外说明
<!-- 如果有需要 Reviewer 特别关注的地方，可以在此说明 -->

## 附件
<!-- 如果有需要提交的附件，可以在此附上 -->

## Sourcery 总结

消除由按键操作与回调检测之间的时序竞争导致的钩子健康检查误报。

错误修复：
- 对于长按直通按键，如果回调发生在健康检查检测到按键按下之前，则识别这些回调，从而避免误报“热键未触发”警告。

增强功能：
- 跟踪每个按键最近一次回调的时间，并使用一个短暂的竞争窗口来区分有效的回调活动与真正的钩子故障。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

消除按键回调与健康检查采样之间的竞态误报，并提升钩子故障检测的准确性。

Bug Fixes:
- 修复长按透传键因按键采样与回调执行存在时序竞争而产生的钩子未触发误报。

Enhancements:
- 增强钩子健康检查对按键回调时序的判断，并保留对快速连续按键和真实钩子失效的识别能力。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

消除按键回调与健康检查采样之间的竞态误报，并提升钩子故障检测的准确性。

Bug Fixes:
- 修复长按透传键因按键采样与回调执行存在时序竞争而产生的钩子未触发误报。

Enhancements:
- 增强钩子健康检查对按键回调时序的判断，并保留对快速连续按键和真实钩子失效的识别能力。

</details>

</details>